### PR TITLE
rm extra assert

### DIFF
--- a/lib/davinci_dtr_test_kit/client_groups/shared/dtr_questionnaire_package_request_validation_test.rb
+++ b/lib/davinci_dtr_test_kit/client_groups/shared/dtr_questionnaire_package_request_validation_test.rb
@@ -29,7 +29,7 @@ module DaVinciDTRTestKit
       assert input_params.present?, 'Request does not contain a recognized FHIR object'
       assert_resource_type(:parameters, resource: input_params)
       assert_valid_resource(resource: input_params,
-                            profile_url: 'http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/dtr-qpackage-input-parameters')
+                            profile_url: 'http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/dtr-qpackage-input-parameters|2.0.1')
     end
   end
 end

--- a/lib/davinci_dtr_test_kit/client_groups/shared/dtr_questionnaire_response_basic_conformance_test.rb
+++ b/lib/davinci_dtr_test_kit/client_groups/shared/dtr_questionnaire_response_basic_conformance_test.rb
@@ -22,7 +22,7 @@ module DaVinciDTRTestKit
       assert_resource_type(:questionnaire_response, resource: questionnaire_response)
 
       assert_valid_resource(resource: questionnaire_response,
-                            profile_url: 'http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/dtr-questionnaireresponse')
+                            profile_url: 'http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/dtr-questionnaireresponse|2.0.1')
     end
   end
 end

--- a/lib/davinci_dtr_test_kit/dtr_questionnaire_response_validation.rb
+++ b/lib/davinci_dtr_test_kit/dtr_questionnaire_response_validation.rb
@@ -88,7 +88,7 @@ module DaVinciDTRTestKit
         end
 
         origin_extension = find_extension(target_item_answer,
-                                          'http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/information-origin')
+                                          'http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/information-origin|2.0.1')
         source_extension = find_extension(origin_extension, 'source')
 
         unless source_extension.present?
@@ -134,7 +134,7 @@ module DaVinciDTRTestKit
 
         # check origin.source extension
         origin_extension = find_extension(answer,
-                                          'http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/information-origin')
+                                          'http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/information-origin|2.0.1')
         source_extension = find_extension(origin_extension, 'source')
 
         if source_extension.present?

--- a/lib/davinci_dtr_test_kit/payer_server_groups/adaptive_next_questionnaire_expressions_test.rb
+++ b/lib/davinci_dtr_test_kit/payer_server_groups/adaptive_next_questionnaire_expressions_test.rb
@@ -6,7 +6,7 @@ module DaVinciDTRTestKit
     id :dtr_v201_payer_adaptive_next_form_expressions_test
     title 'Questionnaire(s) contains items with expressions necessary for pre-population'
     description %(
-      Inferno checks that the payer server response has appropriate expressions and that expressions are
+      Inferno checks that the payer server response to $next-question operation has appropriate expressions and that expressions are
        written in cql.
     )
 

--- a/lib/davinci_dtr_test_kit/payer_server_groups/payer_server_adaptive_request_validation_test.rb
+++ b/lib/davinci_dtr_test_kit/payer_server_groups/payer_server_adaptive_request_validation_test.rb
@@ -21,6 +21,7 @@ module DaVinciDTRTestKit
 
     run do
       skip_if retrieval_method == 'Static', 'Performing only static flow tests - only one flow is required.'
+      profile_with_version = 'http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/dtr-qpackage-input-parameters|2.0.1'
       if initial_adaptive_questionnaire_request.nil?
         resources = load_tagged_requests(QUESTIONNAIRE_TAG)
         using_manual_entry = false
@@ -32,13 +33,12 @@ module DaVinciDTRTestKit
       perform_request_validation_test(
         resources,
         :parameters,
-        'http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/dtr-qpackage-input-parameters',
+        profile_with_version,
         questionnaire_package_url,
         using_manual_entry
       )
-    rescue Inferno::Exceptions::AssertionException => e
-      msg = e.message.to_s.strip
-      skip msg
+      errors_found = messages.any? { |message| message[:type] == 'error' }
+      skip_if errors_found, "Resource does not conform to the profile #{profile_with_version}"
     end
   end
 end

--- a/lib/davinci_dtr_test_kit/payer_server_groups/payer_server_adaptive_request_validation_test.rb
+++ b/lib/davinci_dtr_test_kit/payer_server_groups/payer_server_adaptive_request_validation_test.rb
@@ -13,9 +13,6 @@ module DaVinciDTRTestKit
       values. CodeableConcept element bindings will fail if none of their codings have a code/system belonging
       to the bound ValueSet. Quantity, Coding, and code element bindings will fail if their code/system are not found in
       the valueset.
-
-      This test may process multiple resources, labeling messages with the corresponding tested resources
-      in the order that they were received.
     )
     id :payer_server_adaptive_questionnaire_request_validation
 
@@ -23,20 +20,14 @@ module DaVinciDTRTestKit
       skip_if retrieval_method == 'Static', 'Performing only static flow tests - only one flow is required.'
       profile_with_version = 'http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/dtr-qpackage-input-parameters|2.0.1'
       if initial_adaptive_questionnaire_request.nil?
-        resources = load_tagged_requests(QUESTIONNAIRE_TAG)
-        using_manual_entry = false
+        requests = load_tagged_requests(QUESTIONNAIRE_TAG)
+        skip_if requests.blank?, 'No request resource received from the client.'
+        # making the assumption that only one request was made here - if there were multiple, we are only validating the first
+        resource_is_valid?(resource: FHIR.from_contents(requests[0].request[:body]), profile_url: profile_with_version)
       else
-        resources = initial_adaptive_questionnaire_request
-        using_manual_entry = true
+        request = FHIR.from_contents(initial_adaptive_questionnaire_request)
+        resource_is_valid?(resource: request, profile_url: profile_with_version)
       end
-      skip_if resources.nil?, 'No request resources to validate.'
-      perform_request_validation_test(
-        resources,
-        :parameters,
-        profile_with_version,
-        questionnaire_package_url,
-        using_manual_entry
-      )
       errors_found = messages.any? { |message| message[:type] == 'error' }
       skip_if errors_found, "Resource does not conform to the profile #{profile_with_version}"
     end

--- a/lib/davinci_dtr_test_kit/payer_server_groups/payer_server_adaptive_request_validation_test.rb
+++ b/lib/davinci_dtr_test_kit/payer_server_groups/payer_server_adaptive_request_validation_test.rb
@@ -3,7 +3,7 @@ module DaVinciDTRTestKit
   class PayerAdaptiveFormRequestTest < Inferno::Test
     include URLs
     include DaVinciDTRTestKit::ValidationTest
-    title '[USER INPUT VALIDATION] Questionnaire Package request is valid'
+    title 'User Input Validation: Questionnaire Package request is valid'
     description %(
       This test validates the conformance of the client's request to the
       [DTR Questionnaire Package Input Parameters](http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/dtr-qpackage-input-parameters)

--- a/lib/davinci_dtr_test_kit/payer_server_groups/payer_server_adaptive_response_bundles_validation_test.rb
+++ b/lib/davinci_dtr_test_kit/payer_server_groups/payer_server_adaptive_response_bundles_validation_test.rb
@@ -33,8 +33,7 @@ module DaVinciDTRTestKit
         end
       end
       if !test_passed && !tests_failed[profile_url].blank?
-        raise assert test_passed,
-                     "Not all returned resources conform to the profile: #{profile_url}"
+        assert test_passed, "Not all returned resources conform to the profile: #{profile_url}"
       end
     end
   end

--- a/lib/davinci_dtr_test_kit/payer_server_groups/payer_server_adaptive_response_bundles_validation_test.rb
+++ b/lib/davinci_dtr_test_kit/payer_server_groups/payer_server_adaptive_response_bundles_validation_test.rb
@@ -20,19 +20,22 @@ module DaVinciDTRTestKit
 
     run do
       skip_if retrieval_method == 'Static', 'Performing only static flow tests - only one flow is required.'
-      test_passed = false
+      test_passed = true
       profile_url = 'http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/DTR-QPackageBundle|2.0.1'
       assert !scratch[:adaptive_responses].nil?, 'No resources to validate.'
       scratch[:adaptive_responses].each_with_index do |resource, index|
         fhir_resource = FHIR.from_contents(resource.response[:body])
         fhir_resource.parameter.each do |param|
           resource_is_valid = validate_resource(param.resource, :bundle, profile_url, index)
-          test_passed = true if resource_is_valid
+          test_passed = false unless resource_is_valid
         rescue StandardError
           next
         end
       end
-      raise assert test_passed, "No returned resources conform to the profile: #{profile_url}" if !test_passed && !tests_failed[profile_url].blank?
+      if !test_passed && !tests_failed[profile_url].blank?
+        raise assert test_passed,
+                     "Not all returned resources conform to the profile: #{profile_url}"
+      end
     end
   end
 end

--- a/lib/davinci_dtr_test_kit/payer_server_groups/payer_server_adaptive_response_bundles_validation_test.rb
+++ b/lib/davinci_dtr_test_kit/payer_server_groups/payer_server_adaptive_response_bundles_validation_test.rb
@@ -21,7 +21,7 @@ module DaVinciDTRTestKit
     run do
       skip_if retrieval_method == 'Static', 'Performing only static flow tests - only one flow is required.'
       test_passed = false
-      profile_url = 'http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/DTR-QPackageBundle'
+      profile_url = 'http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/DTR-QPackageBundle|2.0.1'
       assert !scratch[:adaptive_responses].nil?, 'No resources to validate.'
       scratch[:adaptive_responses].each_with_index do |resource, index|
         fhir_resource = FHIR.from_contents(resource.response[:body])
@@ -32,9 +32,7 @@ module DaVinciDTRTestKit
           next
         end
       end
-      raise tests_failed[profile_url][0] if !test_passed && !tests_failed[profile_url].blank?
-
-      messages.clear if test_passed
+      raise assert test_passed, "No returned resources conform to the profile: #{profile_url}" if !test_passed && !tests_failed[profile_url].blank?
     end
   end
 end

--- a/lib/davinci_dtr_test_kit/payer_server_groups/payer_server_adaptive_response_search_validation_test.rb
+++ b/lib/davinci_dtr_test_kit/payer_server_groups/payer_server_adaptive_response_search_validation_test.rb
@@ -21,7 +21,7 @@ module DaVinciDTRTestKit
     run do
       skip_if retrieval_method == 'Static', 'Performing only static flow tests - only one flow is required.'
       test_passed = true
-      profile_url = 'http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/dtr-questionnaire-adapt-search'
+      profile_url = 'http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/dtr-questionnaire-adapt-search|2.0.1'
       assert !scratch[:adaptive_responses].nil?, 'No resources to validate.'
       scratch[:adaptive_responses].each_with_index do |resource, index|
         fhir_resource = FHIR.from_contents(resource.response[:body])
@@ -35,8 +35,7 @@ module DaVinciDTRTestKit
         end
       end
       if !test_passed && !tests_failed[profile_url].blank?
-        raise assert test_passed,
-                     "Not all returned resources conform to the profile: #{profile_url}"
+        assert test_passed, "Not all returned resources conform to the profile: #{profile_url}"
       end
     end
   end

--- a/lib/davinci_dtr_test_kit/payer_server_groups/payer_server_adaptive_response_search_validation_test.rb
+++ b/lib/davinci_dtr_test_kit/payer_server_groups/payer_server_adaptive_response_search_validation_test.rb
@@ -20,7 +20,7 @@ module DaVinciDTRTestKit
 
     run do
       skip_if retrieval_method == 'Static', 'Performing only static flow tests - only one flow is required.'
-      test_passed = false
+      test_passed = true
       profile_url = 'http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/dtr-questionnaire-adapt-search'
       assert !scratch[:adaptive_responses].nil?, 'No resources to validate.'
       scratch[:adaptive_responses].each_with_index do |resource, index|
@@ -28,14 +28,16 @@ module DaVinciDTRTestKit
         fhir_resource.parameter.each do |param|
           param.resource.entry.each do |entry|
             resource_is_valid = validate_resource(entry.resource, :questionnaire, profile_url, index)
-            test_passed = true if resource_is_valid
+            test_passed = false unless resource_is_valid
           end
         rescue StandardError
           next
         end
       end
-      raise assert test_passed, "No returned resources conform to the profile: http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/dtr-questionnaire-adapt-search" if !test_passed && !tests_failed[profile_url].blank?
-
+      if !test_passed && !tests_failed[profile_url].blank?
+        raise assert test_passed,
+                     "Not all returned resources conform to the profile: #{profile_url}"
+      end
     end
   end
 end

--- a/lib/davinci_dtr_test_kit/payer_server_groups/payer_server_adaptive_response_search_validation_test.rb
+++ b/lib/davinci_dtr_test_kit/payer_server_groups/payer_server_adaptive_response_search_validation_test.rb
@@ -34,9 +34,8 @@ module DaVinciDTRTestKit
           next
         end
       end
-      raise tests_failed[profile_url][0] if !test_passed && !tests_failed[profile_url].blank?
+      raise assert test_passed, "No returned resources conform to the profile: http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/dtr-questionnaire-adapt-search" if !test_passed && !tests_failed[profile_url].blank?
 
-      messages.clear if test_passed
     end
   end
 end

--- a/lib/davinci_dtr_test_kit/payer_server_groups/payer_server_next_request_validation_test.rb
+++ b/lib/davinci_dtr_test_kit/payer_server_groups/payer_server_next_request_validation_test.rb
@@ -49,7 +49,7 @@ module DaVinciDTRTestKit
           using_manual_entry
         )
       else
-        messages << { type: 'eror',
+        messages << { type: 'error',
         message: format_markdown("No resources were of type 'Parameters' or 'QuestionnaireResponse'") }
       end
       errors_found = messages.any? { |message| message[:type] == 'error' }

--- a/lib/davinci_dtr_test_kit/payer_server_groups/payer_server_next_request_validation_test.rb
+++ b/lib/davinci_dtr_test_kit/payer_server_groups/payer_server_next_request_validation_test.rb
@@ -49,13 +49,11 @@ module DaVinciDTRTestKit
           using_manual_entry
         )
       else
-        messages << { type: 'warning',
-        message: format_markdown("Resource does not conform to the either
-        #  accepted profiles: http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaireresponse-adapt
-        #  or http://hl7.org/fhir/uv/sdc/StructureDefinition/parameters-questionnaire-next-question-in") }
+        messages << { type: 'eror',
+        message: format_markdown("No resources were of type 'Parameters' or 'QuestionnaireResponse'") }
       end
       errors_found = messages.any? { |message| message[:type] == 'error' }
-      skip_if errors_found, "Resource does not conform to the profiles http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaireresponse-adapt
+      skip_if errors_found, "No resources conform to the profiles http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaireresponse-adapt
         or http://hl7.org/fhir/uv/sdc/StructureDefinition/parameters-questionnaire-next-question-in"
     end
   end

--- a/lib/davinci_dtr_test_kit/payer_server_groups/payer_server_next_request_validation_test.rb
+++ b/lib/davinci_dtr_test_kit/payer_server_groups/payer_server_next_request_validation_test.rb
@@ -49,13 +49,14 @@ module DaVinciDTRTestKit
           using_manual_entry
         )
       else
-        raise new Inferno::Exceptions::AssertionException.new "Resource does not conform to the either
-         accepted profiles: http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaireresponse-adapt
-         or http://hl7.org/fhir/uv/sdc/StructureDefinition/parameters-questionnaire-next-question-in"
+        messages << { type: 'warning',
+        message: format_markdown("Resource does not conform to the either
+        #  accepted profiles: http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaireresponse-adapt
+        #  or http://hl7.org/fhir/uv/sdc/StructureDefinition/parameters-questionnaire-next-question-in") }
       end
-    rescue Inferno::Exceptions::AssertionException => e
-      msg = e.message.to_s.strip
-      skip msg
+      errors_found = messages.any? { |message| message[:type] == 'error' }
+      skip_if errors_found, "Resource does not conform to the profiles http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaireresponse-adapt
+        or http://hl7.org/fhir/uv/sdc/StructureDefinition/parameters-questionnaire-next-question-in"
     end
   end
 end

--- a/lib/davinci_dtr_test_kit/payer_server_groups/payer_server_next_request_validation_test.rb
+++ b/lib/davinci_dtr_test_kit/payer_server_groups/payer_server_next_request_validation_test.rb
@@ -3,7 +3,7 @@ module DaVinciDTRTestKit
   class PayerAdaptiveFormNextRequestTest < Inferno::Test
     include URLs
     include DaVinciDTRTestKit::ValidationTest
-    title '[USER INPUT VALIDATION] Next Question request is valid'
+    title 'User Input Validation:  Next Question request is valid'
     description %(
       This test validates the conformance of the client's request to the
       [SDC Parameters Next Question In](http://hl7.org/fhir/uv/sdc/StructureDefinition/parameters-questionnaire-next-question-in)

--- a/lib/davinci_dtr_test_kit/payer_server_groups/payer_server_next_response_validation_test.rb
+++ b/lib/davinci_dtr_test_kit/payer_server_groups/payer_server_next_response_validation_test.rb
@@ -15,7 +15,6 @@ module DaVinciDTRTestKit
       the valueset.
 
       This test may process multiple resources, labeling messages with the corresponding tested resources
-      This test may process multiple resources, labeling messages with the corresponding tested resources
       in the order that they were received.
     )
 
@@ -38,6 +37,9 @@ module DaVinciDTRTestKit
         :questionnaireResponse,
         'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaireresponse'
       )
+      errors_found = messages.any? { |message| message[:type] == 'error' }
+      skip_if errors_found, "No resources conform to the profiles http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaireresponse-adapt
+        or http://hl7.org/fhir/uv/sdc/StructureDefinition/parameters-questionnaire-next-question-in"
     end
   end
 end

--- a/lib/davinci_dtr_test_kit/payer_server_groups/static_form_request_validation_test.rb
+++ b/lib/davinci_dtr_test_kit/payer_server_groups/static_form_request_validation_test.rb
@@ -22,28 +22,25 @@ module DaVinciDTRTestKit
 
     run do
       skip_if retrieval_method == 'Adaptive', 'Performing only adaptive flow tests - only one flow is required.'
+      profile_with_version = 'http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/dtr-qpackage-input-parameters|2.0.1'
       if initial_static_questionnaire_request.nil?
         using_manual_entry = false
         skip_if access_token.nil?, 'No access token provided - required for client flow.'
         resources = load_tagged_requests(QUESTIONNAIRE_TAG)
         skip_if resources.blank?, 'No request resource received from the client.'
-        assert perform_request_validation_test(
+        perform_request_validation_test(
           resources,
           :parameters,
-          'http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/dtr-qpackage-input-parameters',
+          profile_with_version,
           questionnaire_package_url,
           using_manual_entry
         )
       else
-        # TODO: fix redundant logic here
-        skip_if initial_static_questionnaire_request.nil?, 'No request resource was provided - required for manual flow'
-        assert_valid_json(initial_static_questionnaire_request)
         request = FHIR.from_contents(initial_static_questionnaire_request)
-        assert_valid_resource(resource: request, profile_url: 'http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/dtr-qpackage-input-parameters')
+        resource_is_valid?(resource: request, profile_url: profile_with_version)
       end
-    rescue Inferno::Exceptions::AssertionException => e
-      msg = e.message.to_s.strip
-      skip msg
+      errors_found = messages.any? { |message| message[:type] == 'error' }
+      skip_if errors_found, "Resource does not conform to the profile #{profile_with_version}"
     end
   end
 end

--- a/lib/davinci_dtr_test_kit/payer_server_groups/static_form_request_validation_test.rb
+++ b/lib/davinci_dtr_test_kit/payer_server_groups/static_form_request_validation_test.rb
@@ -5,7 +5,7 @@ module DaVinciDTRTestKit
     include DaVinciDTRTestKit::ValidationTest
     include URLs
     id :dtr_v201_payer_static_form_request_validation_test
-    title '[USER INPUT VALIDATION] Client sends payer server a request for a static form'
+    title 'User Input Validation:  Client sends payer server a request for a static form'
     description %(
       Inferno will validate that the request to the payer server conforms to the
        [Input Parameters profile](http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/dtr-qpackage-input-parameters).

--- a/lib/davinci_dtr_test_kit/payer_server_groups/static_form_request_validation_test.rb
+++ b/lib/davinci_dtr_test_kit/payer_server_groups/static_form_request_validation_test.rb
@@ -39,7 +39,7 @@ module DaVinciDTRTestKit
         skip_if initial_static_questionnaire_request.nil?, 'No request resource was provided - required for manual flow'
         assert_valid_json(initial_static_questionnaire_request)
         request = FHIR.from_contents(initial_static_questionnaire_request)
-        assert assert_valid_resource(resource: request, profile_url: 'http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/dtr-qpackage-input-parameters')
+        assert_valid_resource(resource: request, profile_url: 'http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/dtr-qpackage-input-parameters')
       end
     rescue Inferno::Exceptions::AssertionException => e
       msg = e.message.to_s.strip

--- a/lib/davinci_dtr_test_kit/payer_server_groups/static_form_request_validation_test.rb
+++ b/lib/davinci_dtr_test_kit/payer_server_groups/static_form_request_validation_test.rb
@@ -14,9 +14,6 @@ module DaVinciDTRTestKit
        values. CodeableConcept element bindings will fail if none of their codings have a code/system belonging
        to the bound ValueSet. Quantity, Coding, and code element bindings will fail if their code/system
        are not found in the valueset.
-
-       This test may process multiple resources, labeling messages with the corresponding tested resources
-       in the order that they were received.
     )
     input :initial_static_questionnaire_request, :access_token, :retrieval_method
 
@@ -24,17 +21,11 @@ module DaVinciDTRTestKit
       skip_if retrieval_method == 'Adaptive', 'Performing only adaptive flow tests - only one flow is required.'
       profile_with_version = 'http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/dtr-qpackage-input-parameters|2.0.1'
       if initial_static_questionnaire_request.nil?
-        using_manual_entry = false
         skip_if access_token.nil?, 'No access token provided - required for client flow.'
-        resources = load_tagged_requests(QUESTIONNAIRE_TAG)
-        skip_if resources.blank?, 'No request resource received from the client.'
-        perform_request_validation_test(
-          resources,
-          :parameters,
-          profile_with_version,
-          questionnaire_package_url,
-          using_manual_entry
-        )
+        requests = load_tagged_requests(QUESTIONNAIRE_TAG)
+        skip_if requests.blank?, 'No request resource received from the client.'
+        # making the assumption that only one request was made here - if there were multiple, we are only validating the first
+        resource_is_valid?(resource: FHIR.from_contents(requests[0].request[:body]), profile_url: profile_with_version)
       else
         request = FHIR.from_contents(initial_static_questionnaire_request)
         resource_is_valid?(resource: request, profile_url: profile_with_version)

--- a/lib/davinci_dtr_test_kit/payer_server_groups/static_form_response_validation_test.rb
+++ b/lib/davinci_dtr_test_kit/payer_server_groups/static_form_response_validation_test.rb
@@ -15,23 +15,19 @@ module DaVinciDTRTestKit
       to the bound ValueSet. Quantity, Coding, and code element bindings will fail if their code/system are not found in
       the valueset.
 
-      This test may process multiple resources, labeling messages with the corresponding tested resources
-      in the order that they were received.
     )
     input :url
 
     run do
       skip_if retrieval_method == 'Adaptive', 'Performing only adaptive flow tests - only one flow is required.'
+      profile_with_version = 'http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/dtr-qpackage-output-parameters|2.0.1'
       if initial_static_questionnaire_request.nil?
         skip_if access_token.nil?, 'No access token provided - required for client flow.'
         resources = load_tagged_requests(QUESTIONNAIRE_TAG)
         skip_if resources.nil?, 'No request resource received from the client.'
         scratch[:output_parameters] = resources
-        perform_response_validation_test(
-          resources,
-          :parameters,
-          'http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/dtr-qpackage-output-parameters'
-        )
+        # making the assumption that only one response was received- if there were multiple, we are only validating the first
+        resource_is_valid?(resource: FHIR.from_contents(resources[0].request[:body]), profile_url: profile_with_version)
       else
         request = fhir_operation("#{url}/Questionnaire/$questionnaire-package",
                                  body: JSON.parse(initial_static_questionnaire_request),
@@ -41,14 +37,10 @@ module DaVinciDTRTestKit
         scratch[:output_parameters] = resource
         assert_response_status([200, 201], response: request.response)
         assert_resource_type(:parameters, resource:)
-        perform_response_validation_test(
-          [request],
-          :parameters,
-          'http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/dtr-qpackage-output-parameters'
-        )
+        resource_is_valid?(resource: resource, profile_url: profile_with_version)
         questionnaire_bundle = resource.parameter.find { |param| param.resource.resourceType == 'Bundle' }&.resource
         assert questionnaire_bundle, 'No questionnaire bundle found in the response'
-        assert_valid_resource(resource: questionnaire_bundle, profile_url: 'http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/DTR-QPackageBundle')
+        assert_valid_resource(resource: questionnaire_bundle, profile_url: 'http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/DTR-QPackageBundle|2.0.1')
       end
     end
   end

--- a/lib/davinci_dtr_test_kit/payer_server_groups/static_form_response_validation_test.rb
+++ b/lib/davinci_dtr_test_kit/payer_server_groups/static_form_response_validation_test.rb
@@ -27,7 +27,7 @@ module DaVinciDTRTestKit
         skip_if resources.nil?, 'No request resource received from the client.'
         scratch[:output_parameters] = resources
         # making the assumption that only one response was received- if there were multiple, we are only validating the first
-        resource_is_valid?(resource: FHIR.from_contents(resources[0].request[:body]), profile_url: profile_with_version)
+        assert_valid_resource(resource: FHIR.from_contents(resources[0].request[:body]), profile_url: profile_with_version)
       else
         request = fhir_operation("#{url}/Questionnaire/$questionnaire-package",
                                  body: JSON.parse(initial_static_questionnaire_request),
@@ -36,8 +36,8 @@ module DaVinciDTRTestKit
         resource = FHIR.from_contents(request.response[:body])
         scratch[:output_parameters] = resource
         assert_response_status([200, 201], response: request.response)
-        assert_resource_type(:parameters, resource:)
-        resource_is_valid?(resource: resource, profile_url: profile_with_version)
+        assert_resource_type(:parameters, resource: resource)
+        assert_valid_resource(resource: resource, profile_url: profile_with_version)
         questionnaire_bundle = resource.parameter.find { |param| param.resource.resourceType == 'Bundle' }&.resource
         assert questionnaire_bundle, 'No questionnaire bundle found in the response'
         assert_valid_resource(resource: questionnaire_bundle, profile_url: 'http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/DTR-QPackageBundle|2.0.1')

--- a/lib/davinci_dtr_test_kit/validation_test.rb
+++ b/lib/davinci_dtr_test_kit/validation_test.rb
@@ -5,15 +5,17 @@ module DaVinciDTRTestKit
     end
 
     def validate_resource(fhir_resource, resource_type, profile_url, index)
-      assert fhir_resource.present?, 'Resource does not contain a recognized FHIR object'
       begin
+        assert fhir_resource.present?, 'Resource does not contain a recognized FHIR object'
         assert_resource_type(resource_type, resource: fhir_resource)
         assert_valid_resource(resource: fhir_resource,
                               profile_url:)
       rescue StandardError => e
         self.add_message('error', e.message)
         messages.each do |message|
-          message[:message].prepend("[Resource #{index + 1}] ")
+          unless message[:message].start_with? "[Resource"
+            message[:message].prepend("[Resource #{index + 1}] ")
+          end
         end
         if tests_failed[profile_url].blank?
           tests_failed[profile_url] = [e]

--- a/spec/davinci_dtr_test_kit/dtr_payer_server_static_request_spec.rb
+++ b/spec/davinci_dtr_test_kit/dtr_payer_server_static_request_spec.rb
@@ -31,10 +31,25 @@ RSpec.describe DaVinciDTRTestKit::DTRPayerServerQuestionnairePackageGroup do
 
     describe 'static Questionnaire request validation' do
       let(:runnable) { group.tests.find { |test| test.id.to_s.end_with? 'static_form_request_validation_test' } }
+      let(:input_validation_test) do
+        Class.new(Inferno::Test) do
+          validator do
+            url ENV.fetch('FHIR_RESOURCE_VALIDATOR_URL')
+          end
+
+          input :url, :access_token, :retrieval_method, :initial_static_questionnaire_request
+
+          run do
+            resource_is_valid?(resource:, profile_url: 'http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/dtr-qpackage-input-parameters|2.0.1')
+            errors_found = messages.any? { |message| message[:type] == 'error' }
+            skip_if errors_found, "Resource does not conform to the profile http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/dtr-qpackage-input-parameters|2.0.1"
+          end
+        end
+      end
 
       it 'passes if questionnaire request is conformant' do
         allow_any_instance_of(DaVinciDTRTestKit::PayerStaticFormRequestValidationTest).to(
-          receive(:assert_valid_resource).and_return(true)
+          receive(:resource_is_valid?).and_return(true)
         )
 
         result = run(runnable, test_session, access_token:, retrieval_method:, initial_static_questionnaire_request:)
@@ -46,14 +61,14 @@ RSpec.describe DaVinciDTRTestKit::DTRPayerServerQuestionnairePackageGroup do
           File.read(File.join(__dir__, '..', 'fixtures', 'questionnaire_package_input_params_non_conformant.json'))
         end
 
-        # it 'skips if questionnaire request is not conformant' do
-        #   allow_any_instance_of(DaVinciDTRTestKit::PayerStaticFormRequestValidationTest).to(
-        #     receive(:assert_valid_resource).and_return(false)
-        #   )
+        before do
+          Inferno::Repositories::Tests.new.insert(input_validation_test)
+        end
 
-        #   result = run(runnable, test_session, access_token:, retrieval_method:, initial_static_questionnaire_request:)
-        #   expect(result.result).to eq('skip'), result.result_message
-        # end
+        it 'skips if questionnaire request is not conformant' do
+          result = run(input_validation_test, test_session, access_token:, retrieval_method:, initial_static_questionnaire_request:)
+          expect(result.result).to eq('skip'), result.result_message
+        end
       end
     end
 
@@ -120,6 +135,7 @@ RSpec.describe DaVinciDTRTestKit::DTRPayerServerQuestionnairePackageGroup do
     describe 'static questionnaire package request validation test' do
       let(:runnable) { group.tests.find { |test| test.id.to_s.end_with? 'static_form_request_validation_test' } }
       let(:results_repo) { Inferno::Repositories::Results.new }
+      let(:validation_url) { "#{ENV.fetch('FHIR_RESOURCE_VALIDATOR_URL')}/validate" }
 
       it 'skips when access_token is nil' do
         result = run(runnable, test_session, retrieval_method:)
@@ -130,7 +146,15 @@ RSpec.describe DaVinciDTRTestKit::DTRPayerServerQuestionnairePackageGroup do
         allow_any_instance_of(DaVinciDTRTestKit::URLs).to(receive(:questionnaire_package_url).and_return(
                                                             questionnaire_package_url
                                                           ))
-        allow_any_instance_of(runnable).to(receive(:perform_request_validation_test)).and_return(true)
+        runnable.validator do
+          url ENV.fetch('FHIR_RESOURCE_VALIDATOR_URL')
+        end
+
+        stub_request(:post, validation_url)
+          .with(query: {
+                  profile: 'http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/dtr-qpackage-input-parameters|2.0.1'
+                })
+          .to_return(status: 200, body: FHIR::OperationOutcome.new.to_json)
 
         result = repo_create(:result, test_session_id: test_session.id)
         repo_create(:request, result_id: result.id, name: 'questionnaire_package', url: questionnaire_package_url,
@@ -145,7 +169,6 @@ RSpec.describe DaVinciDTRTestKit::DTRPayerServerQuestionnairePackageGroup do
         allow_any_instance_of(DaVinciDTRTestKit::URLs).to(receive(:questionnaire_package_url).and_return(
                                                             questionnaire_package_url
                                                           ))
-        allow_any_instance_of(runnable).to(receive(:perform_request_validation_test)).and_return(false)
         result = repo_create(:result, test_session_id: test_session.id)
         repo_create(:request, result_id: result.id, name: 'questionnaire_package', url: questionnaire_package_url,
                               request_body: request_body_non_conformant, test_session_id: test_session.id,

--- a/spec/davinci_dtr_test_kit/dtr_payer_server_static_request_spec.rb
+++ b/spec/davinci_dtr_test_kit/dtr_payer_server_static_request_spec.rb
@@ -46,14 +46,14 @@ RSpec.describe DaVinciDTRTestKit::DTRPayerServerQuestionnairePackageGroup do
           File.read(File.join(__dir__, '..', 'fixtures', 'questionnaire_package_input_params_non_conformant.json'))
         end
 
-        it 'skips if questionnaire request is not conformant' do
-          allow_any_instance_of(DaVinciDTRTestKit::PayerStaticFormRequestValidationTest).to(
-            receive(:assert_valid_resource).and_return(false)
-          )
+        # it 'skips if questionnaire request is not conformant' do
+        #   allow_any_instance_of(DaVinciDTRTestKit::PayerStaticFormRequestValidationTest).to(
+        #     receive(:assert_valid_resource).and_return(false)
+        #   )
 
-          result = run(runnable, test_session, access_token:, retrieval_method:, initial_static_questionnaire_request:)
-          expect(result.result).to eq('skip'), result.result_message
-        end
+        #   result = run(runnable, test_session, access_token:, retrieval_method:, initial_static_questionnaire_request:)
+        #   expect(result.result).to eq('skip'), result.result_message
+        # end
       end
     end
 

--- a/spec/davinci_dtr_test_kit/dtr_payer_server_static_response_validation_spec.rb
+++ b/spec/davinci_dtr_test_kit/dtr_payer_server_static_response_validation_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe DaVinciDTRTestKit::DTRPayerServerQuestionnairePackageGroup do
             perform_response_validation_test(
               [request],
               :parameters,
-              'http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/dtr-qpackage-output-parameters'
+              'http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/dtr-qpackage-output-parameters|2.0.1'
             )
             questionnaire_bundle = resource.parameter.find { |param| param.resource.resourceType == 'Bundle' }&.resource
             assert questionnaire_bundle, 'No questionnaire bundle found in the response'
@@ -65,13 +65,13 @@ RSpec.describe DaVinciDTRTestKit::DTRPayerServerQuestionnairePackageGroup do
         )
         stub_request(:post, validation_url)
           .with(query: {
-                  profile: 'http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/dtr-qpackage-output-parameters'
+                  profile: 'http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/dtr-qpackage-output-parameters|2.0.1'
                 })
           .to_return(status: 200, body: FHIR::OperationOutcome.new.to_json)
 
         stub_request(:post, validation_url)
           .with(query: {
-                  profile: 'http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/DTR-QPackageBundle'
+                  profile: 'http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/DTR-QPackageBundle|2.0.1'
                 })
           .to_return(status: 200, body: FHIR::OperationOutcome.new.to_json)
         result = run(output_validation_test, test_session, url:, access_token:,
@@ -87,7 +87,7 @@ RSpec.describe DaVinciDTRTestKit::DTRPayerServerQuestionnairePackageGroup do
         )
         stub_request(:post, validation_url)
           .with(query: {
-                  profile: 'http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/dtr-qpackage-output-parameters'
+                  profile: 'http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/dtr-qpackage-output-parameters|2.0.1'
                 })
           .with(body: output_params_non_conformant)
           .to_return(status: 200, body: FHIR::OperationOutcome.new(issue: { severity: 'error' }).to_json)

--- a/spec/davinci_dtr_test_kit/shared_setup.rb
+++ b/spec/davinci_dtr_test_kit/shared_setup.rb
@@ -13,8 +13,10 @@ RSpec.shared_context('when running standard tests') do |group,
   let(:retrieval_method) { retrieval_method }
   let(:access_token) { '1234' }
   let(:test_session) { repo_create(:test_session, test_suite_id: suite_id) }
+  let(:validation_url) { "#{ENV.fetch('FHIR_RESOURCE_VALIDATOR_URL')}/validate" }
 
   def run(runnable, test_session, inputs = {})
+
     test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
     test_run = Inferno::Repositories::TestRuns.new.create(test_run_params)
     inputs.each do |name, value|


### PR DESCRIPTION
# Summary
- refactoring request validation. The `perform_request_validation_test` method is only really useful when there are multiple requests to validate. This is only the case when taking multiple next-question requests.
- updating the request validation spec tests (adjusting stubs)
- adjusted how messages were presented for readability
- some general clean up of text (e.g. [User Input Validation] removed), some duplicate text deleted

# Testing Guidance

Run server tests against the Smart App tests
Run spec tests

To see updated messages run static or adaptive tests against the server. The main change in presentation is that only next-question requests/responses and the checks on adaptive responses (e.g. 2.07 + 2.08) should indicate the [Resource X] label since the other requests/responses should be singular.

**note:** I do notice that one of the response validation fails with the new validator running the static server tests against the smart app suite. Might be an issue with the response resource - It is not finding the questionnairePackageBundle resource