### PR TITLE
FI-3094: Example JWT fix

### DIFF
--- a/lib/davinci_dtr_test_kit/client_groups/dinner_static/dtr_smart_app_dinner_questionnaire_package_request_test.rb
+++ b/lib/davinci_dtr_test_kit/client_groups/dinner_static/dtr_smart_app_dinner_questionnaire_package_request_test.rb
@@ -119,7 +119,7 @@ module DaVinciDTRTestKit
           an `Authorization` header with value:
 
           ```
-          Bearer eyJhbGcmOiJub25lIn0.#{example_client_jwt_payload_part}.
+          Bearer eyJhbGciOiJub25lIn0.#{example_client_jwt_payload_part}.
           ```
 
           ### Continuing the Tests


### PR DESCRIPTION
# Summary

Somehow there's a wrong character in the example JWT header