### PR TITLE
FI-3222: DTR Client Tests: Use Random Number for Attestation Continuation Links

### DIFF
--- a/lib/davinci_dtr_test_kit/client_groups/dinner_static/dtr_full_ehr_launch_attestation_test.rb
+++ b/lib/davinci_dtr_test_kit/client_groups/dinner_static/dtr_full_ehr_launch_attestation_test.rb
@@ -1,3 +1,4 @@
+require 'securerandom'
 require_relative '../../urls'
 
 module DaVinciDTRTestKit
@@ -9,18 +10,18 @@ module DaVinciDTRTestKit
     description %(
       Attest that DTR has been launched for a patient with data that will be used for prepopulation.
     )
-    input :access_token
 
     run do
+      random_id = SecureRandom.uuid
       wait(
-        identifier: access_token,
+        identifier: random_id,
         message: %(
           I attest that DTR has been launched in the context of a patient with an official name, including
           first and last.
 
-          [Click here](#{resume_pass_url}?token=#{access_token}) if the above statement is **true**.
+          [Click here](#{resume_pass_url}?token=#{random_id}) if the above statement is **true**.
 
-          [Click here](#{resume_fail_url}?token=#{access_token}) if the above statement is **false**.
+          [Click here](#{resume_fail_url}?token=#{random_id}) if the above statement is **false**.
         )
       )
     end

--- a/lib/davinci_dtr_test_kit/client_groups/dinner_static/dtr_full_ehr_prepopulation_attestation_test.rb
+++ b/lib/davinci_dtr_test_kit/client_groups/dinner_static/dtr_full_ehr_prepopulation_attestation_test.rb
@@ -1,3 +1,4 @@
+require 'securerandom'
 require_relative '../../urls'
 
 module DaVinciDTRTestKit
@@ -9,20 +10,19 @@ module DaVinciDTRTestKit
     description %(
       Validate that pre-population of patient name information occurs as expected.
     )
-    input :access_token
-
     run do
+      random_id = SecureRandom.uuid
       wait(
-        identifier: access_token,
+        identifier: random_id,
         message: %(
           I attest that the DTR application pre-populates the following questions with the respective
           value for the official name of the patient:
           - Last Name
           - First Name
 
-          [Click here](#{resume_pass_url}?token=#{access_token}) if the above statement is **true**.
+          [Click here](#{resume_pass_url}?token=#{random_id}) if the above statement is **true**.
 
-          [Click here](#{resume_fail_url}?token=#{access_token}) if the above statement is **false**.
+          [Click here](#{resume_fail_url}?token=#{random_id}) if the above statement is **false**.
         )
       )
     end

--- a/lib/davinci_dtr_test_kit/client_groups/dinner_static/dtr_full_ehr_prepopulation_override_attestation_test.rb
+++ b/lib/davinci_dtr_test_kit/client_groups/dinner_static/dtr_full_ehr_prepopulation_override_attestation_test.rb
@@ -1,3 +1,4 @@
+require 'securerandom'
 require_relative '../../urls'
 
 module DaVinciDTRTestKit
@@ -9,17 +10,16 @@ module DaVinciDTRTestKit
     description %(
       Validate that the user can edit a pre-populated item and replace it with another value.
     )
-    input :access_token
-
     run do
+      random_id = SecureRandom.uuid
       wait(
-        identifier: access_token,
+        identifier: random_id,
         message: %(
           I attest that I have changed the prepopulated value in the First Name field to a new value.
 
-          [Click here](#{resume_pass_url}?token=#{access_token}) if the above statement is **true**.
+          [Click here](#{resume_pass_url}?token=#{random_id}) if the above statement is **true**.
 
-          [Click here](#{resume_fail_url}?token=#{access_token}) if the above statement is **false**.
+          [Click here](#{resume_fail_url}?token=#{random_id}) if the above statement is **false**.
         )
       )
     end

--- a/lib/davinci_dtr_test_kit/client_groups/dinner_static/dtr_full_ehr_rendering_enabled_questions_attestation_test.rb
+++ b/lib/davinci_dtr_test_kit/client_groups/dinner_static/dtr_full_ehr_rendering_enabled_questions_attestation_test.rb
@@ -1,3 +1,4 @@
+require 'securerandom'
 require_relative '../../urls'
 
 module DaVinciDTRTestKit
@@ -10,19 +11,18 @@ module DaVinciDTRTestKit
       Validate that the rendering of the questionnaire includes only the "What would you like on..."
       question appropriate for the dinner selection, if made.
     )
-    input :access_token
-
     run do
+      random_id = SecureRandom.uuid
       wait(
-        identifier: access_token,
+        identifier: random_id,
         message: %(
           I attest that the client application does not display any "What would you like on..."
           questions until I have selected a dinner choice and then only displays the
           "What would you like on..." question relevant for the dinner request:
 
-          [Click here](#{resume_pass_url}?token=#{access_token}) if the above statement is **true**.
+          [Click here](#{resume_pass_url}?token=#{random_id}) if the above statement is **true**.
 
-          [Click here](#{resume_fail_url}?token=#{access_token}) if the above statement is **false**.
+          [Click here](#{resume_fail_url}?token=#{random_id}) if the above statement is **false**.
         )
       )
     end

--- a/lib/davinci_dtr_test_kit/client_groups/dinner_static/dtr_full_ehr_store_attestation_test.rb
+++ b/lib/davinci_dtr_test_kit/client_groups/dinner_static/dtr_full_ehr_store_attestation_test.rb
@@ -1,3 +1,4 @@
+require 'securerandom'
 require_relative '../../urls'
 
 module DaVinciDTRTestKit
@@ -10,18 +11,17 @@ module DaVinciDTRTestKit
       Attest that the questionnaire has been completed and the response has been persisted
       and can be exported as a FHIR QuestionnaireResponse instance.
     )
-    input :access_token
-
     run do
+      random_id = SecureRandom.uuid
       wait(
-        identifier: access_token,
+        identifier: random_id,
         message: %(
           I attest that the questionnaire has been completed and stored within the EHR for future
           use and export as a FHIR QuestionnaireResponse instance.
 
-          [Click here](#{resume_pass_url}?token=#{access_token}) if the above statement is **true**.
+          [Click here](#{resume_pass_url}?token=#{random_id}) if the above statement is **true**.
 
-          [Click here](#{resume_fail_url}?token=#{access_token}) if the above statement is **false**.
+          [Click here](#{resume_fail_url}?token=#{random_id}) if the above statement is **false**.
         )
       )
     end

--- a/lib/davinci_dtr_test_kit/client_groups/dinner_static/dtr_smart_app_prepopulation_attestation_test.rb
+++ b/lib/davinci_dtr_test_kit/client_groups/dinner_static/dtr_smart_app_prepopulation_attestation_test.rb
@@ -1,3 +1,4 @@
+require 'securerandom'
 require_relative '../../urls'
 
 module DaVinciDTRTestKit
@@ -9,19 +10,18 @@ module DaVinciDTRTestKit
     description %(
       Validate that pre-population of patient name information occurs as expected.
     )
-    input :client_id
-
     run do
+      random_id = SecureRandom.uuid
       wait(
-        identifier: client_id,
+        identifier: random_id,
         message: %(
           I attest that the client application pre-populates the following questions with the respective values:
           - Last Name: Oster
           - First Name: William
 
-          [Click here](#{resume_pass_url}?client_id=#{client_id}) if the above statement is **true**.
+          [Click here](#{resume_pass_url}?client_id=#{random_id}) if the above statement is **true**.
 
-          [Click here](#{resume_fail_url}?client_id=#{client_id}) if the above statement is **false**.
+          [Click here](#{resume_fail_url}?client_id=#{random_id}) if the above statement is **false**.
         )
       )
     end

--- a/lib/davinci_dtr_test_kit/client_groups/dinner_static/dtr_smart_app_prepopulation_override_attestation_test.rb
+++ b/lib/davinci_dtr_test_kit/client_groups/dinner_static/dtr_smart_app_prepopulation_override_attestation_test.rb
@@ -1,3 +1,4 @@
+require 'securerandom'
 require_relative '../../urls'
 
 module DaVinciDTRTestKit
@@ -9,20 +10,20 @@ module DaVinciDTRTestKit
     description %(
       Validate that the user can edit a pre-populated item and replace it with another value.
     )
-    input :client_id
 
     run do
+      random_id = SecureRandom.uuid
       wait(
-        identifier: client_id,
+        identifier: random_id,
         message: %(
           I attest that
 
           1. The client pre-populated an answer for question 'Location'.
           2. I have changed the answer to a different value.
 
-          [Click here](#{resume_pass_url}?client_id=#{client_id}) if the above statement is **true**.
+          [Click here](#{resume_pass_url}?client_id=#{random_id}) if the above statement is **true**.
 
-          [Click here](#{resume_fail_url}?client_id=#{client_id}) if the above statement is **false**.
+          [Click here](#{resume_fail_url}?client_id=#{random_id}) if the above statement is **false**.
         )
       )
     end

--- a/lib/davinci_dtr_test_kit/client_groups/dinner_static/dtr_smart_app_rendering_enabled_questions_attestation_test.rb
+++ b/lib/davinci_dtr_test_kit/client_groups/dinner_static/dtr_smart_app_rendering_enabled_questions_attestation_test.rb
@@ -1,3 +1,4 @@
+require 'securerandom'
 require_relative '../../urls'
 
 module DaVinciDTRTestKit
@@ -10,19 +11,18 @@ module DaVinciDTRTestKit
       Validate that the rendering of the questionnaire includes only the "What would you like on..."
       question appropriate for the dinner selection, if made.
     )
-    input :client_id
-
     run do
+      random_id = SecureRandom.uuid
       wait(
-        identifier: client_id,
+        identifier: random_id,
         message: %(
           I attest that the client application does not display any "What would you like on..."
           questions until I have selected a dinner choice and then only displays the
           "What would you like on..." question relevant for the dinner request:
 
-          [Click here](#{resume_pass_url}?client_id=#{client_id}) if the above statement is **true**.
+          [Click here](#{resume_pass_url}?client_id=#{random_id}) if the above statement is **true**.
 
-          [Click here](#{resume_fail_url}?client_id=#{client_id}) if the above statement is **false**.
+          [Click here](#{resume_fail_url}?client_id=#{random_id}) if the above statement is **false**.
         )
       )
     end

--- a/lib/davinci_dtr_test_kit/client_groups/resp_assist_device/dtr_questionnaire_rendering_attestation_test.rb
+++ b/lib/davinci_dtr_test_kit/client_groups/resp_assist_device/dtr_questionnaire_rendering_attestation_test.rb
@@ -12,7 +12,7 @@ module DaVinciDTRTestKit
       questionnaire package and attest that the application renders the questionnaire.
     )
 
-    config(options: {token: SecureRandom.uuid})
+    config(options: { token: SecureRandom.uuid })
 
     def token
       config.options[:token]

--- a/lib/davinci_dtr_test_kit/client_groups/resp_assist_device/dtr_questionnaire_rendering_attestation_test.rb
+++ b/lib/davinci_dtr_test_kit/client_groups/resp_assist_device/dtr_questionnaire_rendering_attestation_test.rb
@@ -7,8 +7,8 @@ module DaVinciDTRTestKit
     id :dtr_questionnaire_rendering_attestation
     title 'Check that the client renders the questionnaire (Attestation)'
     description %(
-      Thist test provides the tester an opportunity to observe their client application following the receipt of the
-      questionnaire pacakage and attest that the application renders the questionnaire.
+      This test provides the tester an opportunity to observe their client application following the receipt of the
+      questionnaire package and attest that the application renders the questionnaire.
     )
     input :client_id
 

--- a/lib/davinci_dtr_test_kit/client_groups/resp_assist_device/dtr_questionnaire_rendering_attestation_test.rb
+++ b/lib/davinci_dtr_test_kit/client_groups/resp_assist_device/dtr_questionnaire_rendering_attestation_test.rb
@@ -10,21 +10,24 @@ module DaVinciDTRTestKit
       This test provides the tester an opportunity to observe their client application following the receipt of the
       questionnaire package and attest that the application renders the questionnaire.
     )
-    input :client_id
+
+    def token
+      SecureRandom.uuid
+    end
 
     run do
       load_tagged_requests QUESTIONNAIRE_PACKAGE_TAG
       skip_if request.blank?, 'A Questionnaire Package request must be made prior to running this test'
 
       wait(
-        identifier: client_id,
+        identifier: token,
         message: %(
           I attest that the client application displays the questionnaire and respects the following rendering style:
           - The "Signature" field label is rendered with green text
 
-          [Click here](#{resume_pass_url}?client_id=#{client_id}) if the above statement is **true**.
+          [Click here](#{resume_pass_url}?token=#{token}) if the above statement is **true**.
 
-          [Click here](#{resume_fail_url}?client_id=#{client_id}) if the above statement is **false**.
+          [Click here](#{resume_fail_url}?token=#{token}) if the above statement is **false**.
         )
       )
     end

--- a/lib/davinci_dtr_test_kit/client_groups/resp_assist_device/dtr_questionnaire_rendering_attestation_test.rb
+++ b/lib/davinci_dtr_test_kit/client_groups/resp_assist_device/dtr_questionnaire_rendering_attestation_test.rb
@@ -1,3 +1,4 @@
+require 'securerandom'
 require_relative '../../urls'
 
 module DaVinciDTRTestKit
@@ -11,8 +12,10 @@ module DaVinciDTRTestKit
       questionnaire package and attest that the application renders the questionnaire.
     )
 
+    config(options: {token: SecureRandom.uuid})
+
     def token
-      SecureRandom.uuid
+      config.options[:token]
     end
 
     run do

--- a/lib/davinci_dtr_test_kit/client_groups/resp_assist_device/dtr_questionnaire_rendering_attestation_test.rb
+++ b/lib/davinci_dtr_test_kit/client_groups/resp_assist_device/dtr_questionnaire_rendering_attestation_test.rb
@@ -12,15 +12,10 @@ module DaVinciDTRTestKit
       questionnaire package and attest that the application renders the questionnaire.
     )
 
-    config(options: { token: SecureRandom.uuid })
-
-    def token
-      config.options[:token]
-    end
-
     run do
       load_tagged_requests QUESTIONNAIRE_PACKAGE_TAG
       skip_if request.blank?, 'A Questionnaire Package request must be made prior to running this test'
+      token = SecureRandom.uuid
 
       wait(
         identifier: token,

--- a/lib/davinci_dtr_test_kit/dtr_smart_app_suite.rb
+++ b/lib/davinci_dtr_test_kit/dtr_smart_app_suite.rb
@@ -100,11 +100,11 @@ module DaVinciDTRTestKit
     end
 
     resume_test_route :get, RESUME_PASS_PATH do |request|
-      DTRSmartAppSuite.extract_token_from_query_params(request)
+      DTRSmartAppSuite.extract_query_param_value(request)
     end
 
     resume_test_route :get, RESUME_FAIL_PATH, result: 'fail' do |request|
-      DTRSmartAppSuite.extract_token_from_query_params(request)
+      DTRSmartAppSuite.extract_query_param_value(request)
     end
 
     # TODO: Update based on SMART Launch changes. Do we even want to have this group now?

--- a/lib/davinci_dtr_test_kit/dtr_smart_app_suite.rb
+++ b/lib/davinci_dtr_test_kit/dtr_smart_app_suite.rb
@@ -100,11 +100,11 @@ module DaVinciDTRTestKit
     end
 
     resume_test_route :get, RESUME_PASS_PATH do |request|
-      DTRSmartAppSuite.extract_client_id_from_query_params(request)
+      DTRSmartAppSuite.extract_token_from_query_params(request)
     end
 
     resume_test_route :get, RESUME_FAIL_PATH, result: 'fail' do |request|
-      DTRSmartAppSuite.extract_client_id_from_query_params(request)
+      DTRSmartAppSuite.extract_token_from_query_params(request)
     end
 
     # TODO: Update based on SMART Launch changes. Do we even want to have this group now?

--- a/lib/davinci_dtr_test_kit/mock_auth_server.rb
+++ b/lib/davinci_dtr_test_kit/mock_auth_server.rb
@@ -166,6 +166,11 @@ module DaVinciDTRTestKit
       request.query_parameters['client_id']
     end
 
+    def extract_query_param_value(request)
+      extract_client_id_from_query_params(request) ||
+        extract_token_from_query_params(request)
+    end
+
     def extract_client_id_from_bearer_token(request)
       token = extract_bearer_token(request)
       jwt =

--- a/spec/davinci_dtr_test_kit/dtr_questionnaire_package_group_spec.rb
+++ b/spec/davinci_dtr_test_kit/dtr_questionnaire_package_group_spec.rb
@@ -47,7 +47,6 @@ RSpec.describe DaVinciDTRTestKit::DTRQuestionnairePackageGroup do
              "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.#{encoded_client_id}"
       post(questionnaire_package_url, request_body)
       expect(last_response.ok?).to be(true)
-
       get(resume_pass_url)
 
       result = results_repo.find(result.id)

--- a/spec/davinci_dtr_test_kit/dtr_questionnaire_rendering_group_spec.rb
+++ b/spec/davinci_dtr_test_kit/dtr_questionnaire_rendering_group_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe DaVinciDTRTestKit::DTRQuestionnaireRenderingGroup do
         test_session_id: test_session.id,
         name:,
         value:,
-        type: runnable.config.input_type(name)
+        type: runnable.config.input_type(name) || :text
       )
     end
     Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
@@ -29,7 +29,11 @@ RSpec.describe DaVinciDTRTestKit::DTRQuestionnaireRenderingGroup do
   describe 'Behavior of questionnaire rendering attestation test' do
     let(:runnable) { group.tests.find { |test| test.id.to_s.end_with? 'dtr_questionnaire_rendering_attestation' } }
     let(:results_repo) { Inferno::Repositories::Results.new }
-    let(:client_id) { '1234' }
+    let(:token) { '1234' }
+
+    before do
+      allow_any_instance_of(runnable).to receive(:token).and_return(token)
+    end
 
     it 'passes if affirmative attestation is given' do
       # For some reason it seems to completely ignore an allow...receive for resume_pass_url, so do this instead
@@ -41,10 +45,10 @@ RSpec.describe DaVinciDTRTestKit::DTRQuestionnaireRenderingGroup do
       repo_create(:request, result_id: result.id, name: 'questionnaire_package', request_body: nil,
                             test_session_id: test_session.id, tags: [DaVinciDTRTestKit::QUESTIONNAIRE_PACKAGE_TAG])
 
-      result = run(runnable, test_session, client_id:)
+      result = run(runnable, test_session)
       expect(result.result).to eq('wait')
 
-      get("#{resume_pass_url}?client_id=#{client_id}")
+      get("#{resume_pass_url}?token=#{token}")
 
       result = results_repo.find(result.id)
       expect(result.result).to eq('pass')
@@ -60,10 +64,10 @@ RSpec.describe DaVinciDTRTestKit::DTRQuestionnaireRenderingGroup do
       repo_create(:request, result_id: result.id, name: 'questionnaire_package', request_body: nil,
                             test_session_id: test_session.id, tags: [DaVinciDTRTestKit::QUESTIONNAIRE_PACKAGE_TAG])
 
-      result = run(runnable, test_session, client_id:)
+      result = run(runnable, test_session)
       expect(result.result).to eq('wait')
 
-      get("#{resume_fail_url}?client_id=#{client_id}")
+      get("#{resume_fail_url}?token=#{token}")
 
       result = results_repo.find(result.id)
       expect(result.result).to eq('fail')

--- a/spec/davinci_dtr_test_kit/dtr_questionnaire_rendering_group_spec.rb
+++ b/spec/davinci_dtr_test_kit/dtr_questionnaire_rendering_group_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe DaVinciDTRTestKit::DTRQuestionnaireRenderingGroup do
   let(:resume_fail_url) { "/custom/#{suite_id}/resume_fail" }
   let(:session_data_repo) { Inferno::Repositories::SessionData.new }
   let(:test_session) { repo_create(:test_session, test_suite_id: suite_id) }
+  let(:test_runs_repo) { Inferno::Repositories::TestRuns.new }
 
   def run(runnable, test_session, inputs = {})
     test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
@@ -29,11 +30,6 @@ RSpec.describe DaVinciDTRTestKit::DTRQuestionnaireRenderingGroup do
   describe 'Behavior of questionnaire rendering attestation test' do
     let(:runnable) { group.tests.find { |test| test.id.to_s.end_with? 'dtr_questionnaire_rendering_attestation' } }
     let(:results_repo) { Inferno::Repositories::Results.new }
-    let(:token) { '1234' }
-
-    before do
-      allow_any_instance_of(runnable).to receive(:token).and_return(token)
-    end
 
     it 'passes if affirmative attestation is given' do
       # For some reason it seems to completely ignore an allow...receive for resume_pass_url, so do this instead
@@ -48,6 +44,7 @@ RSpec.describe DaVinciDTRTestKit::DTRQuestionnaireRenderingGroup do
       result = run(runnable, test_session)
       expect(result.result).to eq('wait')
 
+      token = test_runs_repo.last_test_run(test_session.id).identifier
       get("#{resume_pass_url}?token=#{token}")
 
       result = results_repo.find(result.id)
@@ -67,6 +64,7 @@ RSpec.describe DaVinciDTRTestKit::DTRQuestionnaireRenderingGroup do
       result = run(runnable, test_session)
       expect(result.result).to eq('wait')
 
+      token = test_runs_repo.last_test_run(test_session.id).identifier
       get("#{resume_fail_url}?token=#{token}")
 
       result = results_repo.find(result.id)


### PR DESCRIPTION
# Description

This ticket updated the Full EHR and SMART App attestation tests to use random ids instead of client id tokens

## Important Changes

Removed client id tokens and replaced with random id tokens for the following files
- `lib/davinci_dtr_test_kit/client_groups/dinner_static/dtr_full_ehr_launch_attestation_test.rb`
- `lib/davinci_dtr_test_kit/client_groups/dinner_static/dtr_full_ehr_prepopulation_attestation_test.rb`
- `lib/davinci_dtr_test_kit/client_groups/dinner_static/dtr_full_ehr_prepopulation_override_attestation_test.rb`
- `lib/davinci_dtr_test_kit/client_groups/dinner_static/dtr_full_ehr_rendering_enabled_questions_attestation_test.rb`
- `lib/davinci_dtr_test_kit/client_groups/dinner_static/dtr_full_ehr_store_attestation_test.rb`
- `lib/davinci_dtr_test_kit/client_groups/dinner_static/dtr_smart_app_prepopulation_attestation_test.rb`
- `lib/davinci_dtr_test_kit/client_groups/dinner_static/dtr_smart_app_prepopulation_override_attestation_test.rb`
- `lib/davinci_dtr_test_kit/client_groups/dinner_static/dtr_smart_app_rendering_enabled_questions_attestation_test.rb`

`lib/davinci_dtr_test_kit/client_groups/resp_assist_device/dtr_questionnaire_rendering_attestation_test.rb`
- Fixed Typos
- Update the client id to use a random token value instead this resulted in other changes needed to be made

`lib/davinci_dtr_test_kit/mock_auth_server.rb`
- Defined a function to determine if the query value being used is a client_id or token value

`lib/davinci_dtr_test_kit/dtr_smart_app_suite.rb`
- Updated resume_test_route to use the new defined determine query value function

`spec/davinci_dtr_test_kit/dtr_questionnaire_rendering_group_spec.rb`
- Updated to change client_id usage to token
- Made adjustments to ensure token from `dtr_questionnaire_rendering_attestation_test.rb` was received and returned

## Testing Recommendations

Make sure all unit tests pass (unit tests were not added for this pull request), and the application runs as expected. Run the FullEHR tests to test both expected successes and expected failures. Run the SMART App Test Suite tests to test both expected success and expected failures. 

# Checklists

**Submitter:**
- [x] This MR describes why these changes were made.
- [x] This MR is into the correct branch (usually 'main').
- [x] Comment added to the relevant Jira ticket(s) with a link to this MR.
- [x] The relevant Jira ticket has been moved to 'Peer Review' (may be N/A if a Jira ticket is associated with multiple MRs)
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.).
- [x] Ensure automated tests pass successfully.

**Final Merger**
- [x] The necessary number of reviews/approvals have been received on this PR and all checklists have been completed.
- [x] The relevant Jira ticket has been moved to 'Done' (may N/A if a Jira ticket is associated with multiple MRs)