### PR TITLE
Fix typo in bearer token

### DIFF
--- a/lib/davinci_dtr_test_kit/client_groups/resp_assist_device/dtr_resp_questionnaire_package_request_test.rb
+++ b/lib/davinci_dtr_test_kit/client_groups/resp_assist_device/dtr_resp_questionnaire_package_request_test.rb
@@ -117,7 +117,7 @@ module DaVinciDTRTestKit
           an `Authorization` header with value:
 
           ```
-          Bearer eyJhbGcmOiJub25lIn0.#{example_client_jwt_payload_part}.
+          Bearer eyJhbGciOiJub25lIn0.#{example_client_jwt_payload_part}.
           ```
 
           ### Continuing the Tests


### PR DESCRIPTION
# Summary

When I fixed the typo in the bearer token for the dinner workflow (https://github.com/inferno-framework/davinci-dtr-test-kit/pull/16), I missed that the same typo was present for the respiratory assist device workflow.

# Testing Guidance

Run the respiratory assist device workflow, make a questionnaire package request using the bearer token displayed in the UI