### PR TITLE
headers to application/fhir+json

### DIFF
--- a/lib/davinci_dtr_test_kit/mock_ehr.rb
+++ b/lib/davinci_dtr_test_kit/mock_ehr.rb
@@ -7,7 +7,7 @@ module DaVinciDTRTestKit
     RESOURCE_SERVER_BASE = ENV.fetch('FHIR_REFERENCE_SERVER')
     RESOURCE_SERVER_BEARER_TOKEN = 'SAMPLE_TOKEN'
 
-    RESPONSE_HEADERS = { 'Content-Type' => 'application/json', 'Access-Control-Allow-Origin' => '*' }.freeze
+    RESPONSE_HEADERS = { 'Content-Type' => 'application/fhir+json', 'Access-Control-Allow-Origin' => '*' }.freeze
 
     def resource_server_client
       return @resource_server_client if @resource_server_client
@@ -32,7 +32,7 @@ module DaVinciDTRTestKit
 
       if fhir_class.nil?
         request.status = 400
-        request.response_headers = { 'Content-Type': 'application/json' }
+        request.response_headers = { 'Content-Type': 'application/fhir+json' }
         request.response_body = FHIR::OperationOutcome.new(
           issue: FHIR::OperationOutcome::Issue.new(severity: 'warning', code: 'not-supported',
                                                    details: FHIR::CodeableConcept.new(
@@ -48,7 +48,7 @@ module DaVinciDTRTestKit
         matching_resource = find_resource_in_bundle(ehr_bundle, fhir_class, id)
         if matching_resource.present?
           request.status = 200
-          request.response_headers = { 'Content-Type': 'application/json' }
+          request.response_headers = { 'Content-Type': 'application/fhir+json' }
           request.response_body = matching_resource.to_json
           return
         end

--- a/lib/davinci_dtr_test_kit/mock_payer.rb
+++ b/lib/davinci_dtr_test_kit/mock_payer.rb
@@ -4,7 +4,7 @@ require_relative 'fixtures'
 
 module DaVinciDTRTestKit
   module MockPayer
-    RESPONSE_HEADERS = { 'Content-Type' => 'application/json', 'Access-Control-Allow-Origin' => '*' }.freeze
+    RESPONSE_HEADERS = { 'Content-Type' => 'application/fhir+json', 'Access-Control-Allow-Origin' => '*' }.freeze
 
     def questionnaire_package_response(request, _test = nil, test_result = nil)
       request.status = 200
@@ -19,7 +19,7 @@ module DaVinciDTRTestKit
       client.default_json
       endpoint = endpoint_input.to_h['value'].nil? ? '/Questionnaire/$questionnaire-package' : endpoint_input['value']
       payer_response = client.send(:post, endpoint, JSON.parse(request.request_body),
-                                   { 'Content-Type' => 'application/json' })
+                                   { 'Content-Type' => 'application/fhir+json' })
 
       request.status = 200
       request.response_headers = RESPONSE_HEADERS
@@ -31,7 +31,7 @@ module DaVinciDTRTestKit
       client = FHIR::Client.new(url_endpoint['value'])
       client.default_json
       payer_response = client.send(:post, '/Questionnaire/$next-question', JSON.parse(request.request_body),
-                                   { 'Content-Type' => 'application/json' })
+                                   { 'Content-Type' => 'application/fhir+json' })
 
       request.status = 200
       request.response_headers = RESPONSE_HEADERS

--- a/lib/davinci_dtr_test_kit/payer_server_groups/payer_server_adaptive_response_validation_test.rb
+++ b/lib/davinci_dtr_test_kit/payer_server_groups/payer_server_adaptive_response_validation_test.rb
@@ -32,7 +32,7 @@ module DaVinciDTRTestKit
               load_tagged_requests(QUESTIONNAIRE_TAG)[0]
             else
               fhir_operation("#{url}#{endpoint}", body: JSON.parse(initial_adaptive_questionnaire_request),
-                                                  headers: { 'Content-Type': 'application/json' })
+                                                  headers: { 'Content-Type': 'application/fhir+json' })
             end
 
       assert_response_status([200, 201], response: req.response)

--- a/lib/davinci_dtr_test_kit/payer_server_groups/payer_server_next_response_validation_test.rb
+++ b/lib/davinci_dtr_test_kit/payer_server_groups/payer_server_next_response_validation_test.rb
@@ -27,7 +27,7 @@ module DaVinciDTRTestKit
                json_requests.map do |resource|
                  fhir_operation("#{url}/Questionnaire/$next-question",
                                 body: resource,
-                                headers: { 'Content-Type': 'application/json' })
+                                headers: { 'Content-Type': 'application/fhir+json' })
                end
              end
       assert !reqs.nil?, 'No requests to validate.'

--- a/lib/davinci_dtr_test_kit/payer_server_groups/static_form_response_validation_test.rb
+++ b/lib/davinci_dtr_test_kit/payer_server_groups/static_form_response_validation_test.rb
@@ -29,7 +29,7 @@ module DaVinciDTRTestKit
             else
               fhir_operation("#{url}/Questionnaire/$questionnaire-package",
                              body: JSON.parse(initial_static_questionnaire_request),
-                             headers: { 'Content-Type': 'application/json' })
+                             headers: { 'Content-Type': 'application/fhir+json' })
             end
 
       assert_response_status([200, 201], response: request.response)


### PR DESCRIPTION
# Summary
[Issue](https://github.com/inferno-framework/davinci-dtr-test-kit/issues/32) about headers was raised - these should generally be `application/fhir+json`

# Testing Guidance
Run payer server / EHR suites.
