### PR TITLE
FI-3509: Metadata OAuth URIs

### DIFF
--- a/lib/davinci_dtr_test_kit/dtr_smart_app_suite.rb
+++ b/lib/davinci_dtr_test_kit/dtr_smart_app_suite.rb
@@ -67,7 +67,7 @@ module DaVinciDTRTestKit
     suite_endpoint :post, NEXT_PATH, MockPayer::NextQuestionEndpoint
 
     # EHR
-    route(:get, '/fhir/metadata', MockEHR.method(:metadata))
+    route(:get, METADATA_PATH, MockEHR.method(:metadata))
     suite_endpoint :post, QUESTIONNAIRE_RESPONSE_PATH, MockEHR::QuestionnaireResponseEndpoint
     suite_endpoint :get, FHIR_RESOURCE_PATH, MockEHR::FHIRGetEndpoint
     suite_endpoint :get, FHIR_SEARCH_PATH, MockEHR::FHIRGetEndpoint

--- a/lib/davinci_dtr_test_kit/endpoints/mock_authorization.rb
+++ b/lib/davinci_dtr_test_kit/endpoints/mock_authorization.rb
@@ -62,8 +62,8 @@ module DaVinciDTRTestKit
       base_url = env_base_url(env, OPENID_CONFIG_PATH)
       response_body = {
         issuer: base_url + FHIR_BASE_PATH,
-        authorization_endpoint: base_url + EHR_AUTHORIZE_PATH,
-        token_endpoint: base_url + EHR_TOKEN_PATH,
+        authorization_endpoint: authorization_endpoint(base_url),
+        token_endpoint: token_endpoint(base_url),
         jwks_uri: base_url + JKWS_PATH,
         response_types_supported: ['id_token'],
         subject_types_supported: ['public'],
@@ -78,6 +78,14 @@ module DaVinciDTRTestKit
       path = env['REQUEST_PATH'] || env['PATH_INFO']
       path.gsub!(%r{#{endpoint_path}(/)?}, '')
       "#{protocol}://#{host + path}"
+    end
+
+    def authorization_endpoint(base_url)
+      base_url + EHR_AUTHORIZE_PATH
+    end
+
+    def token_endpoint(base_url)
+      base_url + EHR_TOKEN_PATH
     end
   end
 end

--- a/lib/davinci_dtr_test_kit/endpoints/mock_ehr.rb
+++ b/lib/davinci_dtr_test_kit/endpoints/mock_ehr.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../endpoints/mock_authorization'
+
 module DaVinciDTRTestKit
   module MockEHR
     RESOURCE_SERVER_BASE = ENV.fetch('FHIR_REFERENCE_SERVER')
@@ -13,9 +15,23 @@ module DaVinciDTRTestKit
       client
     end
 
-    def metadata(_env)
+    def metadata(env)
       cs = resource_server_client.capability_statement
       if cs.present?
+        # Overwrite the OAuth URIs returned by the reference server to point to the suite endpoints instead
+        oauth_uris_url = 'http://fhir-registry.smarthealthit.org/StructureDefinition/oauth-uris'
+        base_url = MockAuthorization.env_base_url(env, METADATA_PATH)
+        sec_ext = cs.rest.first&.security&.extension&.delete_if { |e| e.url == oauth_uris_url }
+        sec_ext&.push(
+          FHIR::Extension.new(
+            url: oauth_uris_url,
+            extension: [
+              FHIR::Extension.new(url: 'authorize', valueUri: MockAuthorization.authorization_endpoint(base_url)),
+              FHIR::Extension.new(url: 'token', valueUri: MockAuthorization.token_endpoint(base_url))
+            ]
+          )
+        )
+
         [200, { 'Content-Type' => 'application/fhir+json', 'Access-Control-Allow-Origin' => '*' }, [cs.to_json]]
       else
         [500, { 'Access-Control-Allow-Origin' => '*' }, ['Unexpected error occurred while fetching metadata']]

--- a/lib/davinci_dtr_test_kit/urls.rb
+++ b/lib/davinci_dtr_test_kit/urls.rb
@@ -2,6 +2,7 @@
 
 module DaVinciDTRTestKit
   FHIR_BASE_PATH = '/fhir'
+  METADATA_PATH = "#{FHIR_BASE_PATH}/metadata".freeze
   SMART_CONFIG_PATH = "#{FHIR_BASE_PATH}/.well-known/smart-configuration".freeze
   OPENID_CONFIG_PATH = "#{FHIR_BASE_PATH}/.well-known/openid-configuration".freeze
   JKWS_PATH = "#{FHIR_BASE_PATH}/.well-known/jwks.json".freeze


### PR DESCRIPTION
# Summary

- Overwrite OAuth URIs in metadata proxied response so they point to the suite endpoints rather than the reference server endpoints.
- ~Add Questionnaire to default fhirContext inputs~

This came out of the investigation into launching the DTR reference implementation against Inferno. The RI uses the metadata endpoint to determine the OAuth URIs instead of using /.well-known/smart-configuration. This goes against guidance in the IG, but it's conceivable other client systems could do the same.

Note there are other data elements in the metadata response that aren't representative of how a DTR client can interact with the test suite, but I don't see much benefit from filtering it down further/overwriting more stuff. But at some point it might the most sense to just construct our own CapabilityStatement for the test suite instead of proxy to the reference server.

# Testing Guidance

Run the SMART App suite, make a /metadata request with Postman, confirm the OAuth URIs are as expected.
