### PR TITLE
Release 0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.15.1
+* FI-3463: DTR Light EHR: test supported payer endpoint by @degradification in https://github.com/inferno-framework/davinci-dtr-test-kit/pull/42
+* Fi-3766: Add Full DTR EHR verifies requirements by @elsaperelli in https://github.com/inferno-framework/davinci-dtr-test-kit/pull/57
+* FI-3800: Add Payer Server verifies_requirements by @elsaperelli in https://github.com/inferno-framework/davinci-dtr-test-kit/pull/59
+* Fix typo in metadata title by @Shaumik-Ashraf in https://github.com/inferno-framework/davinci-dtr-test-kit/pull/61
+
 # v0.15.0
 * **Ruby Version Update:** Upgraded Ruby to `3.3.6`.
 * **Inferno Core Update:** Bumped to version `0.6`.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    davinci_dtr_test_kit (0.15.0)
+    davinci_dtr_test_kit (0.15.1)
       inferno_core (~> 0.6.2)
       jwt (~> 2.6)
       smart_app_launch_test_kit (~> 0.5.0)
@@ -142,7 +142,7 @@ GEM
       mutex_m
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
-    inferno_core (0.6.4)
+    inferno_core (0.6.5)
       activesupport (~> 6.1.7.5)
       base62-rb (= 0.3.1)
       blueprinter (= 0.25.2)
@@ -190,7 +190,7 @@ GEM
     mime-types (3.6.0)
       logger
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2025.0220)
+    mime-types-data (3.2025.0304)
     mini_portile2 (2.8.8)
     minitest (5.25.4)
     multi_json (1.15.0)
@@ -246,7 +246,7 @@ GEM
     rake (13.2.1)
     rdoc (6.7.0)
       psych (>= 4.0.0)
-    redis-client (0.23.2)
+    redis-client (0.24.0)
       connection_pool
     regexp_parser (2.9.2)
     reline (0.5.9)
@@ -296,7 +296,7 @@ GEM
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)
       redis-client (>= 0.19.0)
-    smart_app_launch_test_kit (0.5.0)
+    smart_app_launch_test_kit (0.5.1)
       inferno_core (>= 0.6.2)
       json-jwt (~> 1.15.3)
       jwt (~> 2.6)
@@ -329,8 +329,8 @@ GEM
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.6.0)
     unicode_utils (1.4.0)
-    us_core_test_kit (0.10.0)
-      inferno_core (>= 0.6.1)
+    us_core_test_kit (0.10.1)
+      inferno_core (>= 0.6.4)
       smart_app_launch_test_kit (>= 0.5.0)
       tls_test_kit (~> 0.3.0)
     webmock (3.23.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,7 +142,7 @@ GEM
       mutex_m
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
-    inferno_core (0.6.5)
+    inferno_core (0.6.4)
       activesupport (~> 6.1.7.5)
       base62-rb (= 0.3.1)
       blueprinter (= 0.25.2)
@@ -352,6 +352,7 @@ DEPENDENCIES
   davinci_dtr_test_kit!
   debug
   factory_bot (~> 6.1)
+  inferno_core (= 0.6.4)
   rack-test (~> 1.1.0)
   rspec (~> 3.10)
   rubocop (~> 1.9)

--- a/lib/davinci_dtr_test_kit/version.rb
+++ b/lib/davinci_dtr_test_kit/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module DaVinciDTRTestKit
-  VERSION = '0.15.0'
-  LAST_UPDATED = '2025-02-25'
+  VERSION = '0.15.1'
+  LAST_UPDATED = '2025-03-10'
 end


### PR DESCRIPTION
## What's Changed
* FI-3463: DTR Light EHR: test supported payer endpoint by @degradification in https://github.com/inferno-framework/davinci-dtr-test-kit/pull/42
* Fi-3766: Add Full DTR EHR verifies requirements by @elsaperelli in https://github.com/inferno-framework/davinci-dtr-test-kit/pull/57
* FI-3800: Add Payer Server verifies_requirements by @elsaperelli in https://github.com/inferno-framework/davinci-dtr-test-kit/pull/59
* Fix typo in metadata title by @Shaumik-Ashraf in https://github.com/inferno-framework/davinci-dtr-test-kit/pull/61

