### PR TITLE
Release 0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v0.15.1
+* FI-3463: DTR Light EHR: test supported payer endpoint by @degradification in https://github.com/inferno-framework/davinci-dtr-test-kit/pull/42
+* Fi-3766: Add Full DTR EHR verifies requirements by @elsaperelli in https://github.com/inferno-framework/davinci-dtr-test-kit/pull/57
+* FI-3800: Add Payer Server verifies_requirements by @elsaperelli in https://github.com/inferno-framework/davinci-dtr-test-kit/pull/59
+* Fix typo in metadata title by @Shaumik-Ashraf in https://github.com/inferno-framework/davinci-dtr-test-kit/pull/61
+
+
 # v0.15.0
 * **Ruby Version Update:** Upgraded Ruby to `3.3.6`.
 * **Inferno Core Update:** Bumped to version `0.6`.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    davinci_dtr_test_kit (0.15.0)
+    davinci_dtr_test_kit (0.15.1)
       inferno_core (~> 0.6.2)
       jwt (~> 2.6)
       smart_app_launch_test_kit (~> 0.5.0)

--- a/lib/davinci_dtr_test_kit/version.rb
+++ b/lib/davinci_dtr_test_kit/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module DaVinciDTRTestKit
-  VERSION = '0.15.0'
-  LAST_UPDATED = '2025-02-25'
+  VERSION = '0.15.1'
+  LAST_UPDATED = '2025-03-10'
 end


### PR DESCRIPTION
## What's Changed
* FI-3463: DTR Light EHR: test supported payer endpoint by @degradification in https://github.com/inferno-framework/davinci-dtr-test-kit/pull/42
* Fi-3766: Add Full DTR EHR verifies requirements by @elsaperelli in https://github.com/inferno-framework/davinci-dtr-test-kit/pull/57
* FI-3800: Add Payer Server verifies_requirements by @elsaperelli in https://github.com/inferno-framework/davinci-dtr-test-kit/pull/59
* Fix typo in metadata title by @Shaumik-Ashraf in https://github.com/inferno-framework/davinci-dtr-test-kit/pull/61

