### PR TITLE
FI-4124: add smart app limitation documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,7 @@ requirements and may change how these are tested.
 ## Test Scope and Limitations
 
 The DTR specification is complex and evolving and these tests do not yet
-cover the full scope of the specification. In particular, tests have been
-started but not yet released Light DTR EMR actors responsible for launching
-a DTR SMART App and serving data that the app can use to populate questionnaires.
+cover the full scope of the specification.
 
 For the implemented actors, see suite-specific documentation on current limitations
 for the [payer server](lib/davinci_dtr_test_kit/docs/dtr_payer_server_suite_description_v201.md#limitations),

--- a/lib/davinci_dtr_test_kit/docs/dtr_smart_app_suite_description_v201.md
+++ b/lib/davinci_dtr_test_kit/docs/dtr_smart_app_suite_description_v201.md
@@ -197,3 +197,11 @@ to retrieve questionnaires.
 Not all questionnaire features that are must support within the DTR IG are currently represented
 in questionnaires tested by the IG. Additional questionnaires testing additional features will
 be added in the future.
+
+### Client data access
+
+DTR SMART Apps are required to support US Core client capabilities to access data used in
+the completion of questionnaires. While clients must be able to fetch data to demonstrate
+pre-population capabilities, this test suite does not currently check that the app
+can access all US Core and DTR data required by the
+[DTR SMART Client Capability Statement](https://hl7.org/fhir/us/davinci-dtr/STU2/CapabilityStatement-dtr-smart-client.html).


### PR DESCRIPTION
# Summary

Documents the smart app test suite limitation that not all required client data access capabilities are currently tested.

