### PR TITLE
Add additional platform to Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -388,6 +388,7 @@ GEM
     zeitwerk (2.8.2)
 
 PLATFORMS
+  arm64-darwin-23
   arm64-darwin-24
   x86_64-linux-gnu
 


### PR DESCRIPTION
My dev platform wasn't reflected in `Gemfile.lock`. I wanted to do a quick PR to get it in rather than have it show up in subsequent PRs.