### PR TITLE
ID-177: Verify all required questions are answered in $next-question requests

### DIFF
--- a/lib/davinci_dtr_test_kit/cross_suite/v2.2.0/questionnaire_response_completeness.rb
+++ b/lib/davinci_dtr_test_kit/cross_suite/v2.2.0/questionnaire_response_completeness.rb
@@ -1,0 +1,52 @@
+module DaVinciDTRTestKit
+  # Determines whether a QuestionnaireResponse has answers for all of the required questions in the
+  # Questionnaire that it is based on. Used by Inferno's simulated payer server to decide when a
+  # QuestionnaireResponse for an adaptive form is complete, and by the client tests to verify that a
+  # client does not ask for the next question until the current questions have been answered.
+  #
+  # Note that this logic does not take `enableWhen` conditions into account: a required question is
+  # expected to be answered even when its enabling condition is not met.
+  module QuestionnaireResponseCompleteness
+    # The Questionnaire contained within a QuestionnaireResponse, which for an adaptive form holds
+    # the questions disclosed so far.
+    def contained_questionnaire(questionnaire_response)
+      questionnaire_response.contained&.find { |contained_resource| contained_resource.is_a?(FHIR::Questionnaire) }
+    end
+
+    def questionnaire_response_complete?(questionnaire, questionnaire_response)
+      unanswered_required_link_ids(questionnaire, questionnaire_response).empty?
+    end
+
+    # The link ids of the required questions in the questionnaire that do not have an answer in the
+    # questionnaire response. Questions nested within an unanswered required question are omitted.
+    def unanswered_required_link_ids(questionnaire, questionnaire_response)
+      Array(questionnaire.item).flat_map do |item|
+        unanswered_required_link_ids_for_item(item, questionnaire_response.item)
+      end
+    end
+
+    private
+
+    def unanswered_required_link_ids_for_item(item, response_items)
+      response_item = find_response_item(item, response_items)
+      return [item.linkId] if required_and_unanswered?(item, response_item)
+
+      Array(item.item).flat_map do |sub_item|
+        unanswered_required_link_ids_for_item(sub_item, response_item&.item)
+      end
+    end
+
+    def find_response_item(item, response_items)
+      Array(response_items).find { |response_item| response_item.linkId == item.linkId }
+    end
+
+    def required_and_unanswered?(item, response_item)
+      item.required == true && !answer_present?(response_item)
+    end
+
+    def answer_present?(response_item)
+      # an answer value of `false` is a valid answer, so check for nil rather than presence
+      Array(response_item&.answer).any? { |answer| !answer&.value.nil? }
+    end
+  end
+end

--- a/lib/davinci_dtr_test_kit/full_ehr/v2.2.0/full_ehr_next_question_endpoint.rb
+++ b/lib/davinci_dtr_test_kit/full_ehr/v2.2.0/full_ehr_next_question_endpoint.rb
@@ -2,6 +2,7 @@ require 'udap_security_test_kit'
 require_relative '../endpoints/mock_payer'
 require_relative '../../cross_suite/fhirpath_utils'
 require_relative '../../cross_suite/response_selection_utils'
+require_relative '../../cross_suite/v2.2.0/questionnaire_response_completeness'
 require_relative '../fixture_loader'
 require_relative '../../tags'
 
@@ -11,6 +12,7 @@ module DaVinciDTRTestKit
       include MockPayer
       include DaVinciDTRTestKit::FhirpathUtils
       include DaVinciDTRTestKit::ResponseSelectionUtils
+      include DaVinciDTRTestKit::QuestionnaireResponseCompleteness
 
       def test_run_identifier
         return request.params[:session_path] if request.params[:session_path].present?
@@ -115,22 +117,20 @@ module DaVinciDTRTestKit
       end
 
       def extract_contained_questionnaire
-        contained_questionnaire = request_questionnaire_response.contained&.find do |contained_resource|
-          contained_resource.is_a?(FHIR::Questionnaire)
-        end
+        questionnaire = contained_questionnaire(request_questionnaire_response)
 
-        unless contained_questionnaire.present?
+        unless questionnaire.present?
           return operation_outcome('error', 'invalid',
                                    'Invalid QuestionnaireResponse for $next-question request: ' \
                                    'no contained Questionnaire resource.')
         end
-        unless contained_questionnaire.url.present?
+        unless questionnaire.url.present?
           return operation_outcome('error', 'invalid',
                                    'Invalid QuestionnaireResponse for $next-question request: ' \
                                    'contained Questionnaire must have a url.')
         end
 
-        contained_questionnaire
+        questionnaire
       end
 
       # ***********************************************************************
@@ -290,7 +290,10 @@ module DaVinciDTRTestKit
       def update_response
         @new_questions_added = false
         add_questions_from_questionnaire_template
-        complete_questionnaire_response if !@new_questions_added && questionnaire_response_completed?
+        if !@new_questions_added &&
+           questionnaire_response_complete?(request_questionnaire, request_questionnaire_response)
+          complete_questionnaire_response
+        end
         request_questionnaire_response
       rescue FhirpathServiceError => e
         raise if template_from_fixture?
@@ -336,25 +339,6 @@ module DaVinciDTRTestKit
       # ***********************************************************************
       # Complete QuestionnaireResponse
       # ***********************************************************************
-
-      def questionnaire_response_completed?
-        request_questionnaire.item.all? do |item|
-          item_not_required_or_completed?(item, request_questionnaire_response.item)
-        end
-      end
-
-      def item_not_required_or_completed?(item, response_item_list)
-        required = (item.required == true)
-        response_item = response_item_list.find { |response_item| response_item.linkId == item.linkId }
-        not_required_or_completed = !required || answer_completed_and_valid?(item, response_item)
-        return false unless not_required_or_completed
-
-        item.item.all? { |sub_item| item_not_required_or_completed?(sub_item, response_item&.item || []) }
-      end
-
-      def answer_completed_and_valid?(_item, response_item)
-        response_item&.answer&.any? { |answer| !answer&.value.nil? }
-      end
 
       def complete_questionnaire_response
         request_questionnaire_response.status = 'completed'

--- a/lib/davinci_dtr_test_kit/full_ehr/v2.2.0/request/dtr_next_question_request_validation_test.rb
+++ b/lib/davinci_dtr_test_kit/full_ehr/v2.2.0/request/dtr_next_question_request_validation_test.rb
@@ -1,10 +1,12 @@
 require_relative '../../../urls'
 require_relative '../../../cross_suite/v2.2.0/multi_request_message_helper'
+require_relative '../../../cross_suite/v2.2.0/questionnaire_response_completeness'
 
 module DaVinciDTRTestKit
   class DTRFullEHRV220NextQuestionRequestValidationTest < Inferno::Test
     include URLs
     include MultiRequestMessageHelper
+    include QuestionnaireResponseCompleteness
 
     id :dtr_full_ehr_v220_nq_request_validation
     title 'Next Question request is valid'
@@ -18,13 +20,49 @@ module DaVinciDTRTestKit
       values. CodeableConcept element bindings will fail if none of their codings have a code/system belonging
       to the bound ValueSet. Quantity, Coding, and code element bindings will fail if their code/system are not found in
       the valueset.
+
+      This test also verifies that all of the required questions in the QuestionnaireResponse provided in the
+      request have been answered, because the client is not allowed to indicate that the user is ready for
+      the next question until the answers to the current QuestionnaireResponse pass validation rules. The
+      required questions are the items marked `required` in the Questionnaire contained within the
+      QuestionnaireResponse. Note that `enableWhen` conditions are not considered, so a required question
+      is expected to be answered even if its enabling condition is not met.
     )
+    verifies_requirements 'hl7.fhir.us.davinci-dtr_2.2.0@spec-146'
 
     def target_tags
       tags = [CLIENT_NEXT_TAG]
       tags << config.options[:dtr_workflow_tag] if config.options[:dtr_workflow_tag].present?
 
       tags
+    end
+
+    def questionnaire_response_from_parameters(input_params)
+      resource = input_params.parameter.find { |param| param.name == 'questionnaire-response' }&.resource
+      resource if resource.is_a?(FHIR::QuestionnaireResponse)
+    end
+
+    def check_required_questions_answered(questionnaire_response, request_index)
+      questionnaire = contained_questionnaire(questionnaire_response)
+      if questionnaire.blank?
+        add_request_message(
+          'error',
+          'Unable to verify that all required questions have been answered: the QuestionnaireResponse ' \
+          'does not include a contained Questionnaire.',
+          request_index
+        )
+        return
+      end
+
+      unanswered_link_ids = unanswered_required_link_ids(questionnaire, questionnaire_response)
+      return if unanswered_link_ids.empty?
+
+      add_request_message(
+        'error',
+        'All required questions must be answered before requesting the next question. No answer found ' \
+        "for required item(s): #{unanswered_link_ids.map { |link_id| "`#{link_id}`" }.to_sentence}.",
+        request_index
+      )
     end
 
     run do
@@ -54,11 +92,14 @@ module DaVinciDTRTestKit
           resource_is_valid?(resource: input_params,
                              profile_url: 'http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/dtr-questionnaireresponse-adapt|2.2.0',
                              message_prefix: request_prefix(request_index))
+          check_required_questions_answered(input_params, request_index)
 
         elsif input_params.is_a?(FHIR::Parameters)
           resource_is_valid?(resource: input_params,
                              profile_url: 'http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/dtr-next-question-input-parameters|2.2.0',
                              message_prefix: request_prefix(request_index))
+          questionnaire_response = questionnaire_response_from_parameters(input_params)
+          check_required_questions_answered(questionnaire_response, request_index) if questionnaire_response.present?
         else
           add_request_message(
             'error',

--- a/spec/davinci_dtr_test_kit/dtr_full_ehr_v220_next_question_request_validation_test_spec.rb
+++ b/spec/davinci_dtr_test_kit/dtr_full_ehr_v220_next_question_request_validation_test_spec.rb
@@ -1,0 +1,186 @@
+require 'davinci_dtr_test_kit/full_ehr/v2.2.0/request/dtr_next_question_request_validation_test'
+
+RSpec.describe DaVinciDTRTestKit::DTRFullEHRV220NextQuestionRequestValidationTest do # rubocop:disable RSpec/SpecFilePathFormat
+  let(:suite_id) { 'dtr_full_ehr_v220' }
+  let(:results_repo) { Inferno::Repositories::Results.new }
+  let(:runnable) { find_test(suite, 'dtr_full_ehr_v220_nq_request_validation') }
+  let(:next_url) { "#{Inferno::Application['base_url']}/custom/#{suite_id}#{DaVinciDTRTestKit::NEXT_PATH}" }
+  let(:request_tags) { [DaVinciDTRTestKit::CLIENT_NEXT_TAG, 'adaptive'] }
+
+  # The initial $next-question request: the contained Questionnaire has no items yet, so there are
+  # no required questions to answer.
+  let(:initial_request_body) do
+    File.read(File.join(__dir__, '..', 'fixtures', 'next_question_initial_input_params_conformant.json'))
+  end
+
+  # A follow-up $next-question request where every required question in the contained Questionnaire
+  # has an answer.
+  let(:all_answered_request_body) do
+    File.read(File.join(__dir__, '..', 'fixtures', 'next_question_input_params_no_origin_extension.json'))
+  end
+
+  # A follow-up $next-question request where required question `3.1` has no answer.
+  let(:missing_answer_request_body) do
+    File.read(File.join(__dir__, '..', 'fixtures', 'next_question_input_params_missing_answer.json'))
+  end
+
+  before do
+    # Profile validation is exercised elsewhere and requires the validator service.
+    allow_any_instance_of(runnable).to receive(:resource_is_valid?).and_return(true)
+  end
+
+  def build_next_requests(*request_bodies)
+    result = repo_create(:result, test_session_id: test_session.id)
+    request_bodies.each do |request_body|
+      repo_create(:request, result_id: result.id, url: next_url, request_body:,
+                            test_session_id: test_session.id, tags: request_tags)
+    end
+  end
+
+  def result_messages_string
+    results_repo
+      .current_results_for_test_session_and_runnables(test_session.id, [runnable])
+      .first.messages.map(&:message).join("\n")
+  end
+
+  # Builds a $next-question request body containing a QuestionnaireResponse for a Questionnaire with
+  # the provided items. When `wrap_in_parameters` is false the QuestionnaireResponse is the body.
+  def request_body_for(questionnaire_items:, response_items:, wrap_in_parameters: true)
+    questionnaire_response = FHIR::QuestionnaireResponse.new(
+      status: 'in-progress',
+      questionnaire: '#DinnerOrderAdaptive',
+      contained: [
+        FHIR::Questionnaire.new(
+          id: 'DinnerOrderAdaptive',
+          url: 'urn:inferno:dtr-test-kit:dinner-order-adaptive',
+          status: 'draft',
+          item: questionnaire_items
+        )
+      ],
+      item: response_items
+    )
+    return questionnaire_response.to_json unless wrap_in_parameters
+
+    FHIR::Parameters.new(
+      parameter: [
+        FHIR::Parameters::Parameter.new(name: 'questionnaire-response', resource: questionnaire_response)
+      ]
+    ).to_json
+  end
+
+  it 'skips if no $next-question request was made' do
+    result = run(runnable)
+
+    expect(result.result).to eq('skip')
+    expect(result.result_message).to match(/next-question request must be made prior to running this test/)
+  end
+
+  it 'passes when the contained Questionnaire has no questions yet' do
+    build_next_requests(initial_request_body)
+
+    expect(run(runnable).result).to eq('pass')
+  end
+
+  it 'passes when all of the required questions have been answered' do
+    build_next_requests(initial_request_body, all_answered_request_body)
+
+    expect(run(runnable).result).to eq('pass')
+  end
+
+  it 'fails when a required question has not been answered' do
+    build_next_requests(missing_answer_request_body)
+
+    expect(run(runnable).result).to eq('fail')
+    expect(result_messages_string).to match(
+      /All required questions must be answered before requesting the next question.*`3\.1`/
+    )
+  end
+
+  it 'identifies the request containing the unanswered required question' do
+    build_next_requests(initial_request_body, missing_answer_request_body)
+
+    result = run(runnable)
+
+    expect(result.result).to eq('fail')
+    expect(result.result_message).to match(/Request 2:/)
+    expect(result_messages_string).to match(/\(Request 2\) All required questions must be answered/)
+  end
+
+  it 'fails when a required question has not been answered in a bare QuestionnaireResponse body' do
+    build_next_requests(
+      request_body_for(
+        questionnaire_items: [FHIR::Questionnaire::Item.new(linkId: 'Q1', type: 'string', required: true)],
+        response_items: [],
+        wrap_in_parameters: false
+      )
+    )
+
+    expect(run(runnable).result).to eq('fail')
+    expect(result_messages_string).to match(/No answer found for required item\(s\): `Q1`/)
+  end
+
+  it 'fails when a required question nested within an answered question has not been answered' do
+    build_next_requests(
+      request_body_for(
+        questionnaire_items: [
+          FHIR::Questionnaire::Item.new(
+            linkId: 'Q1', type: 'string', required: true,
+            item: [FHIR::Questionnaire::Item.new(linkId: 'Q1.1', type: 'string', required: true)]
+          )
+        ],
+        response_items: [
+          FHIR::QuestionnaireResponse::Item.new(
+            linkId: 'Q1',
+            answer: [FHIR::QuestionnaireResponse::Item::Answer.new(valueString: 'an answer')]
+          )
+        ]
+      )
+    )
+
+    expect(run(runnable).result).to eq('fail')
+    expect(result_messages_string).to match(/No answer found for required item\(s\): `Q1\.1`/)
+  end
+
+  it 'fails when the QuestionnaireResponse does not contain a Questionnaire' do
+    build_next_requests(
+      FHIR::Parameters.new(
+        parameter: [
+          FHIR::Parameters::Parameter.new(
+            name: 'questionnaire-response',
+            resource: FHIR::QuestionnaireResponse.new(status: 'in-progress')
+          )
+        ]
+      ).to_json
+    )
+
+    expect(run(runnable).result).to eq('fail')
+    expect(result_messages_string).to match(/does not include a contained Questionnaire/)
+  end
+
+  it 'passes when unanswered questions are not required' do
+    build_next_requests(
+      request_body_for(
+        questionnaire_items: [FHIR::Questionnaire::Item.new(linkId: 'Q1', type: 'string', required: false)],
+        response_items: []
+      )
+    )
+
+    expect(run(runnable).result).to eq('pass')
+  end
+
+  it 'treats a boolean false answer to a required question as answered' do
+    build_next_requests(
+      request_body_for(
+        questionnaire_items: [FHIR::Questionnaire::Item.new(linkId: 'Q1', type: 'boolean', required: true)],
+        response_items: [
+          FHIR::QuestionnaireResponse::Item.new(
+            linkId: 'Q1',
+            answer: [FHIR::QuestionnaireResponse::Item::Answer.new(valueBoolean: false)]
+          )
+        ]
+      )
+    )
+
+    expect(run(runnable).result).to eq('pass')
+  end
+end

--- a/spec/davinci_dtr_test_kit/full_ehr_v220_next_question_endpoint_spec.rb
+++ b/spec/davinci_dtr_test_kit/full_ehr_v220_next_question_endpoint_spec.rb
@@ -968,7 +968,7 @@ RSpec.describe DaVinciDTRTestKit::MockPayer::FullEHRV220NextQuestionEndpoint, :r
       end
 
       it 'sets the QuestionnaireResponse status to completed when the required item answer value is boolean false' do
-        # Regression guard: answer_completed_and_valid? must use !nil? not .present? so that
+        # Regression guard: QuestionnaireResponseCompleteness#answer_present? must use !nil? not .present? so that
         # false (a valid boolean answer) is not mistaken for a missing answer.
         # Q1 is pre-existing in the contained questionnaire so no new questions are added.
         false_answer_body = FHIR::Parameters.new(


### PR DESCRIPTION
## Summary

Partial implementation of requirement [spec-146](https://hl7.org/fhir/us/davinci-dtr/2.2.0/en/specification.html#ci-c-spec-146): the DTR client must not indicate that the user is ready for the next question until the answers in the current QuestionnaireResponse pass validation rules. This adds a check that every required question in the QuestionnaireResponse sent to `$next-question` has been answered.

## Changes

- Factored the QuestionnaireResponse completeness logic out of the v2.2.0 `$next-question` server simulation into a new shared module, `DaVinciDTRTestKit::QuestionnaireResponseCompleteness` (`lib/davinci_dtr_test_kit/cross_suite/v2.2.0/questionnaire_response_completeness.rb`). It exposes `contained_questionnaire`, `questionnaire_response_complete?` and `unanswered_required_link_ids`.
- `MockPayer::FullEHRV220NextQuestionEndpoint` now includes the module rather than carrying its own copy of the logic. Behavior is unchanged, including treating a boolean `false` as a valid answer and only marking a QuestionnaireResponse as `completed` when no new questions were disclosed.
- `DTRFullEHRV220NextQuestionRequestValidationTest` now uses the same module to verify each `$next-question` request body. The QuestionnaireResponse is taken from either the `Parameters` wrapper or a bare QuestionnaireResponse body, and the required items in its contained Questionnaire are checked against the answers present. Unanswered required questions are reported per request:

  ```
  (Request 2) All required questions must be answered before requesting the next question.
  No answer found for required item(s): `PBD.1`, `PBD.2`, and `LOC.1`.
  ```

  A QuestionnaireResponse with no contained Questionnaire reports that the check could not be
  performed. The test declares `verifies_requirements 'hl7.fhir.us.davinci-dtr_2.2.0@spec-146'`.

Note that `enableWhen` conditions are not taken into account, so a required question is expected to
be answered even when its enabling condition is not met. This matches the existing behavior of the
server simulation and is documented in the module and in the test description.

## Tests

New spec `spec/davinci_dtr_test_kit/dtr_full_ehr_v220_next_question_request_validation_test_spec.rb`
covers the initial request with no questions disclosed yet, a fully answered form, an unanswered
required question, request numbering across multiple requests, a bare QuestionnaireResponse body, a
required question nested under an answered question, a missing contained Questionnaire, unanswered
optional questions, and a boolean `false` answer.

```
bundle exec rspec                # 318 examples, 0 failures
bundle exec rubocop lib spec     # 229 files inspected, no offenses detected
```

Requirements coverage is unchanged (`bundle exec inferno requirements check_coverage dtr_full_ehr_v220`
reports the coverage CSV is up to date). spec-146 appears in the existing warning list of requirements
not present in the suite's requirement sets, because `requirement_sets` is still commented out in
`dtr_full_ehr_suite.rb` for the v2.2.0 suite.

## Test IDs

- Inferno test: `dtr_full_ehr_v220_nq_request_validation`, shown as **2.2.3.01 Next Question request is valid**
  - Full ID: `dtr_full_ehr_v220-dtr_full_ehr_basic_workflows-dtr_full_ehr_v220_workflow_adaptive-Group03-dtr_full_ehr_v220_nq_request_validation`
- Group to run: `dtr_full_ehr_v220_workflow_adaptive`, shown as **2.2 Adaptive Questionnaire**
- Unit tests:
  - `bundle exec rspec spec/davinci_dtr_test_kit/dtr_full_ehr_v220_next_question_request_validation_test_spec.rb`
  - `bundle exec rspec spec/davinci_dtr_test_kit/full_ehr_v220_next_question_endpoint_spec.rb`

## Where to verify in the UI

Da Vinci DTR Client Test Suite v2.2.0 -> **2 Basic Workflows** -> **2.2 Adaptive Questionnaire** ->
**2.2.3 $next-question** -> **2.2.3.01 Next Question request is valid** -> **MESSAGES** tab. The new
check appears as an error message prefixed with the request number. The **REQUESTS** tab of the same
test shows the `$next-question` bodies the messages refer to.

Note that with hand made request bodies this test also reports profile conformance errors, so the
result is red either way. The item to verify is the presence or absence of the
"All required questions must be answered" message.

## UI testing steps

1. Start a session on the Da Vinci DTR Client Test Suite v2.2.0 with the SMART Backend Services
   client type, and select the "Run Against the Client Simulation Suite" preset so the Client Id is
   set to `demo`.
2. Run **1 Client Registration** and complete the attestation so the Client Id is available to the
   rest of the session.
3. Select **2.2 Adaptive Questionnaire** and click RUN TESTS. The Questionnaires wait dialog appears.
4. Send a `$questionnaire-package` request followed by two `$next-question` requests, where the second
   one repeats the form returned by the first without answering the questions that were disclosed:

   ```sh
   CID=demo
   BASE="http://localhost:4567/custom/dtr_full_ehr_v220/fhir/Questionnaire"
   curl -s -X POST "$BASE/\$questionnaire-package?session_path=$CID" \
     -H 'Content-Type: application/fhir+json' \
     --data-binary @spec/fixtures/questionnaire_package_input_params_conformant.json > /dev/null
   curl -s -X POST "$BASE/\$next-question?session_path=$CID" \
     -H 'Content-Type: application/fhir+json' \
     --data-binary @spec/fixtures/next_question_initial_input_params_conformant.json > nq1.json
   curl -s -X POST "$BASE/\$next-question?session_path=$CID" \
     -H 'Content-Type: application/fhir+json' --data-binary @nq1.json > /dev/null
   ```

   The `session_path` query parameter identifies the session without an access token. It also causes
   the existing request URL check to report a wrong URL, which is expected with this shortcut.
5. Click the continuation link in the wait dialog, then the rendering attestation link.
6. Open **2.2.3.01** and check the MESSAGES tab. Request 2 reports `PBD.1`, `PBD.2` and `LOC.1` as
   unanswered required questions.
7. To confirm there are no false positives, repeat steps 1 to 6 in a new session, but add answers for
   `PBD.1` and `PBD.2` under the `PBD` group and `LOC.1` under the `LOC` group in the third request
   body. The message is no longer reported.

## Running the client and server suites against each other

The paired presets let the Client Simulator Suite drive the Client Test Suite, which exercises the
passing path of this check without a real client, because the simulated client answers each disclosed
question before requesting the next one.

1. Session A: Da Vinci DTR Client Test Suite v2.2.0, SMART Backend Services client type, preset
   "Run Against the Client Simulation Suite". Run **1 Client Registration**, then select
   **2.2 Adaptive Questionnaire** and click RUN TESTS so Inferno waits for requests.
2. Session B: Da Vinci DTR Client Simulator Suite v2.2.0, preset "Run Against the DTR Client Suite".
   The preset points the Payer FHIR Server Base Url at
   `<base_url>/custom/dtr_full_ehr_v220/fhir` and uses client id `demo`. Run **1 Backend Services**
   to obtain a token, then run **2 Payer serves Questionnaires**, which sends the
   `$questionnaire-package` and `$next-question` requests to session A.
3. Return to session A, click through the attestation dialogs, and review **2.2.3.01**. No
   "All required questions must be answered" message is reported for these requests.

## UI proof

Test 2.2.3.01 reporting the unanswered required questions for the second `$next-question` request:

![Next Question request is valid reporting unanswered required questions](https://raw.githubusercontent.com/abhinandan2012/davinci-dtr-test-kit/pr-assets-ID-177/01-nq-request-validation-required-answer-error.jpg)

Location of the test in the Adaptive Questionnaire group:

![Location of test 2.2.3.01 within the Adaptive Questionnaire group](https://raw.githubusercontent.com/abhinandan2012/davinci-dtr-test-kit/pr-assets-ID-177/02-nq-request-validation-test-location.jpg)

The same test for a flow where the disclosed questions were answered. Only profile conformance errors
remain and the completeness message is not present:

![Next Question request is valid with all required questions answered](https://raw.githubusercontent.com/abhinandan2012/davinci-dtr-test-kit/pr-assets-ID-177/03-nq-request-validation-answered-no-error.jpg)
