### PR TITLE
FQM-428: Create 2.2 Payer Suite Skeleton

### DIFF
--- a/lib/davinci_dtr_test_kit/cross_suite/v2.2.0/questionnaire_operation_validation.rb
+++ b/lib/davinci_dtr_test_kit/cross_suite/v2.2.0/questionnaire_operation_validation.rb
@@ -1,0 +1,388 @@
+# NOTE: this is just copied from 2.0.1 'cql_test', and hasn't been updated yet
+module DaVinciDTRTestKit
+  module QuestionnaireOperationValidation
+    STATIC_QUESTIONNAIRE_PACKAGE_BUNDLE_PROFILE = 'http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/DTR-QPackageBundle|2.2.0'.freeze
+    STATIC_QUESTIONNAIRE_PACKAGE_PARAMETER_PROFILE = 'http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/dtr-qpackage-output-parameters|2.2.0'.freeze
+    ADAPTIVE_QUESTIONNAIRE_PACKAGE_BUNDLE_PROFILE = 'http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/DTR-QPackageBundle|2.2.0'.freeze
+    ADAPTIVE_QUESTIONNAIRE_PACKAGE_PARAMETER_PROFILE = 'http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/dtr-qpackage-output-parameters|2.2.0'.freeze
+
+    def questionnaire_package_profile_urls
+      {
+        static_bundle: STATIC_QUESTIONNAIRE_PACKAGE_BUNDLE_PROFILE,
+        static_parameter: STATIC_QUESTIONNAIRE_PACKAGE_PARAMETER_PROFILE,
+        adaptive_bundle: ADAPTIVE_QUESTIONNAIRE_PACKAGE_BUNDLE_PROFILE,
+        adaptive_parameter: ADAPTIVE_QUESTIONNAIRE_PACKAGE_PARAMETER_PROFILE
+      }
+    end
+
+    def extension_presence
+      @extension_presence ||= { 'found_min_launch_context' => false, 'found_min_variable' => false,
+                                'found_min_pop_context' => false, 'found_min_init_expression' => false,
+                                'found_min_candidate_expression' => false, 'found_min_context_expression' => false,
+                                'found_min_cqf_lib' => false }
+    end
+
+    def cql_presence
+      @cql_presence ||= { 'launch_context' => true, 'variable' => true,
+                          'pop_context' => true, 'init_expression' => true,
+                          'candidate_expression' => true, 'context_expression' => true }
+    end
+
+    def cqf_reference_libraries
+      scratch[:cqf_reference_libraries] ||= Set.new
+    end
+
+    def library_urls
+      scratch[:library_urls] ||= Set.new
+    end
+
+    def library_names
+      scratch[:library_names] ||= Set.new
+    end
+
+    def found_questionnaire
+      @found_questionnaire ||= false
+    end
+
+    def found_duplicate_library_name
+      @found_duplicate_library_name ||= false
+    end
+
+    def found_non_cql_elm_library
+      @found_non_cql_elm_library ||= false
+    end
+
+    def found_non_cql_expression
+      @found_non_cql_expression ||= false
+    end
+
+    def reset_cql_tests
+      library_names.clear
+      library_urls.clear
+      cqf_reference_libraries.clear
+      extension_presence.each_key { |k| extension_presence[k] = false }
+    end
+
+    def verify_questionnaire_extensions(questionnaires)
+      assert questionnaires&.any? && questionnaires.all?(FHIR::Questionnaire), 'No questionnaires found.'
+      questionnaires.each_with_index { |q, q_index| check_questionnaire_extensions(q, q_index) }
+      check_library_references
+      assert extension_presence.value?(true), 'No extensions found. Questionnaire must demonstrate prepopulation.'
+      assert cql_presence['variable'], 'Variable expression logic not written in CQL.'
+      assert cql_presence['launch_context'], 'Launch context expression logic not written in CQL.'
+      assert cql_presence['pop_context'], 'Population context expression logic not written in CQL.'
+    end
+
+    def check_questionnaire_extensions(questionnaire, q_index)
+      # are extensions present in this questionnaire?
+      found_launch_context = found_variable = found_pop_context = found_cqf_lib = false
+      cqf_count = total_cqf_libs(questionnaire.extension)
+      misformatted_expressions = []
+      questionnaire.extension.each_with_index do |extension, index|
+        if extension.url == 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-launchContext'
+          found_launch_context = true
+          extension_presence['found_min_launch_context'] = true
+          check_for_cql(extension, 'launch_context', index, q_index, extension.url)
+          misformatted_expressions << check_expression_format(extension, index)
+        end
+        if extension.url == 'http://hl7.org/fhir/StructureDefinition/variable'
+          found_variable = true
+          extension_presence['found_min_variable'] = true
+          check_for_cql(extension, 'variable', index, q_index, extension.url)
+          misformatted_expressions << check_expression_format(extension, index)
+        end
+        if extension.url == 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-itemPopulationContext'
+          found_pop_context = true
+          extension_presence['found_min_pop_context'] = true
+          check_for_cql(extension, 'pop_context', index, q_index, extension.url)
+          misformatted_expressions << check_expression_format(extension, index)
+        end
+        next unless extension.url == 'http://hl7.org/fhir/StructureDefinition/cqf-library'
+
+        cqf_reference_libraries.add(extension.valueCanonical)
+        found_cqf_lib = true
+        extension_presence['found_min_cqf_lib'] = true
+
+        check_for_cql(extension, '', index, q_index, extension.url)
+      end
+      add_launch_context_messages(found_launch_context, found_variable, found_pop_context, found_cqf_lib, q_index)
+      return if cqf_count < 1
+
+      add_formatting_messages(misformatted_expressions, q_index)
+      assert misformatted_expressions.compact.empty?, 'Expression in questionnaire misformatted.'
+    end
+
+    def verify_questionnaire_items(questionnaires, final_cql_test: false)
+      assert questionnaires&.any? && questionnaires.all?(FHIR::Questionnaire), 'No questionnaires found.'
+      questionnaires.each_with_index { |q, q_index| check_questionnaire_items(q, q_index) }
+
+      begin
+        assert !found_non_cql_expression, 'Found non-cql expression.'
+        assert extension_presence.value?(true), 'No extensions found. Questionnaire must demonstrate prepopulation.'
+        assert cql_presence['init_expression'], 'Initial expression logic not written in CQL.'
+        assert cql_presence['candidate_expression'], 'Candidate expression logic not written in CQL.'
+        assert cql_presence['context_expression'], 'Context expression logic not written in CQL.'
+      ensure
+        reset_cql_tests if final_cql_test
+      end
+    end
+
+    def add_launch_context_messages(found_launch_context, found_variable, found_pop_context, found_cqf_lib, q_index)
+      unless found_launch_context
+        messages << { type: 'info',
+                      message: format_markdown("[questionnaire #{q_index + 1}] included no launch context.") }
+      end
+      unless found_variable
+        messages << { type: 'info',
+                      message: format_markdown("[questionnaire #{q_index + 1}]
+                       included no variable to query for additional data.") }
+      end
+      unless found_pop_context
+        messages << { type: 'info',
+                      message: format_markdown("[questionnaire #{q_index + 1}]
+                       included no item population context.") }
+      end
+      return if found_cqf_lib
+
+      messages << { type: 'info',
+                    message: format_markdown("[questionnaire #{q_index + 1}]
+                      included no cqf library.") }
+    end
+
+    def add_formatting_messages(misformatted_expressions, q_index)
+      misformatted_expressions.compact.each do |idx|
+        messages << { type: 'info',
+                      message: format_markdown("[expression #{idx + 1}] in [questionnaire #{q_index + 1}]
+                      does not begin with a reference to an included library name.") }
+      end
+    end
+
+    def total_cqf_libs(extensions)
+      cqf_count = 0
+      extensions.each do |extension|
+        next unless extension.url == 'http://hl7.org/fhir/StructureDefinition/cqf-library'
+
+        cqf_count += 1
+      end
+      cqf_count
+    end
+
+    def add_item_messages(found_item_expressions, q_index)
+      unless found_item_expressions['found_candidate_expression']
+        messages << { type: 'info',
+                      message: format_markdown("[questionnaire #{q_index + 1}] included no candidate expression.") }
+      end
+      unless found_item_expressions['found_init_expression']
+        messages << { type: 'info',
+                      message: format_markdown("[questionnaire #{q_index + 1}] included no initial expression.") }
+      end
+      return if found_item_expressions['found_context_expression']
+
+      messages << { type: 'info',
+                    message: format_markdown("[questionnaire #{q_index + 1}] included no context expression.") }
+    end
+
+    def check_questionnaire_items(questionnaire, q_index)
+      # are expressions present in this questionnaire?
+      found_item_expressions = { 'found_init_expression' => false,
+                                 'found_candidate_expression' => false,
+                                 'found_context_expression' => false }
+      cqf_count = total_cqf_libs(questionnaire.extension)
+      misformatted_expressions = []
+
+      # check questionnaire items
+      questionnaire.item.each_with_index do |item, index|
+        misformatted_expressions.concat(check_nested_items(item, index, q_index, found_item_expressions, item.linkId))
+        # check extensions on items
+        item.extension.each do |item_ext|
+          misformatted_expressions << check_item_extension(item_ext,
+                                                           index, q_index, found_item_expressions, item.linkId)
+        end
+      end
+      add_item_messages(found_item_expressions, q_index)
+      # only care about formatting when there are multiple cqf libs
+      return if cqf_count < 1
+
+      misformatted_expressions.compact.to_set.each do |idx|
+        messages << { type: 'info',
+                      message: format_markdown("[item #{idx + 1}] in [questionnaire #{q_index + 1}]
+                      contains expression that does not begin with a reference to an included library name.") }
+      end
+      assert misformatted_expressions.compact.to_set.empty?, 'Expression in questionnaire misformatted.'
+    end
+
+    def evaluate_library(library)
+      found_cql = found_elm = false
+      library.content.each do |content|
+        if content.data.nil?
+          messages << { type: 'info',
+                        message: format_markdown("[library #{library.url}] content element included no data.") }
+        end
+        if content.contentType == 'text/cql'
+          found_cql = true
+        elsif content.contentType == 'application/elm+json'
+          found_elm = true
+        else
+          messages << { type: 'info',
+                        message: format_markdown("[library #{library.url}] has non-cql/elm content.") }
+          true
+        end
+        next unless library_names.include? library.name
+
+        found_duplicate_library_name = true
+        messages << { type: 'info', message: format_markdown("[library #{library.url}] has a name,
+         #{library.name}, that is already included in the bundle.") }
+        assert !found_duplicate_library_name, 'Found duplicate library names - all names must be unique.'
+      end
+      assert found_cql, "[library #{library.url}] does not include CQL."
+      assert found_elm, "[library #{library.url}] does not include ELM."
+    end
+
+    def check_libraries(questionnaire_bundles)
+      libraries = extract_libraries_from_bundles(questionnaire_bundles)
+
+      assert libraries.any?, 'No Libraries found.'
+
+      libraries.each do |lib|
+        library_urls.add(lib.url) unless lib.url.nil?
+        evaluate_library(lib)
+        library_names.add(lib.name)
+      end
+    end
+
+    def check_library_references
+      missing_references = cqf_reference_libraries.select do |url|
+        library_urls.exclude? url
+      end
+      assert missing_references.empty?,
+             "Some libraries referenced by cqf-libraries were not found: #{missing_references.join(', ')}"
+    end
+
+    def check_item_extension(item_ext, index, q_index, found_item_expressions, link_id)
+      if item_ext.url == 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression'
+        found_item_expressions['found_candidate_expression'] = true
+        extension_presence['found_min_candidate_expression'] = true
+        check_for_cql(item_ext, 'candidate_expression', index, q_index, item_ext.url, link_id)
+        return check_expression_format(item_ext, index)
+      end
+      if item_ext.url == 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression'
+        found_item_expressions['found_init_expression'] = true
+        extension_presence['found_min_init_expression'] = true
+        check_for_cql(item_ext, 'init_expression', index, q_index, item_ext.url, link_id)
+        return check_expression_format(item_ext, index)
+      end
+      if item_ext.url == 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-contextExpression'
+        found_item_expressions['found_context_expression'] = true
+        extension_presence['found_min_context_expression'] = true
+        check_for_cql(item_ext, 'context_expression', index, q_index, item_ext.url, link_id)
+        return check_expression_format(item_ext, index)
+      end
+      check_for_cql(item_ext, '', index, q_index, item_ext.url, link_id)
+    end
+
+    def check_nested_items(item, index, q_index, found_item_expressions, link_id)
+      misformatted_nested_expressions = []
+      item.item.each do |nested_item|
+        check_nested_items(nested_item, index, q_index, found_item_expressions, nested_item.linkId)
+        nested_item.extension.each do |item_ext|
+          misformatted_nested_expressions << check_item_extension(item_ext, index, q_index, found_item_expressions,
+                                                                  link_id)
+        end
+      end
+      misformatted_nested_expressions.compact
+    end
+
+    def check_expression_format(item_ext, index)
+      return unless library_names.none?
+
+      expression_passes = false
+      library_names.each do |name|
+        if item_ext.valueExpression.expression.start_with? "\"#{name}\""
+          expression_passes = true
+          break
+        end
+      end
+      index unless expression_passes
+    end
+
+    def check_for_cql(extension, extension_name, index, q_index, url, link_id = '')
+      return if extension.valueExpression.nil?
+      return if extension.valueExpression.language == 'text/cql'
+
+      cql_presence[extension_name] = false unless extension_name.blank?
+      messages << if link_id.blank?
+                    { type: 'info',
+                      message: format_markdown("[extension #{index + 1}] in [questionnaire #{q_index + 1}]
+                          contains expression that does not have content type of cql
+                          (URL: #{url}).") }
+                  else
+                    { type: 'info',
+                      message: format_markdown("[item #{index + 1}] in [questionnaire #{q_index + 1}]
+                          contains expression that does not have content type of cql
+                          (linkId: #{link_id}, URL: #{url}).") }
+                  end
+    end
+
+    def extract_contained_questionnaires(questionnaire_responses)
+      questionnaire_responses&.filter_map do |qr|
+        qr.contained&.grep(FHIR::Questionnaire)
+      end&.flatten&.compact
+    end
+
+    def extract_questionnaires_from_bundles(questionnaire_bundles)
+      questionnaire_bundles.filter_map do |qb|
+        qb.entry.filter_map { |entry| entry.resource if entry.resource.is_a?(FHIR::Questionnaire) }
+      end&.flatten&.compact
+    end
+
+    def perform_questionnaire_package_validation(resource, form = 'static')
+      scratch[:"#{form}_questionnaire_bundles"] = extract_questionnaire_bundles(resource)
+      validate_questionnaire_package(resource, form)
+      assert scratch[:"#{form}_questionnaire_bundles"].present?, 'No questionnaire bundle found in the response'
+    end
+
+    def validate_questionnaire_package(resource, form)
+      case resource&.resourceType
+      when 'Bundle'
+        assert_valid_resource(resource:, profile_url: questionnaire_package_profile_urls[:"#{form}_bundle"])
+      when 'Parameters'
+        assert_valid_resource(resource:, profile_url: questionnaire_package_profile_urls[:"#{form}_parameter"])
+      else
+        assert(false, "Unexpected resourceType: #{resource&.resourceType}. Expected Parameters or Bundle")
+      end
+    end
+
+    def extract_questionnaire_bundles(resource)
+      case resource&.resourceType
+      when 'Bundle'
+        [resource]
+      when 'Parameters'
+        extract_bundles_from_parameter(resource)
+      else
+        []
+      end
+    end
+
+    def extract_bundles_from_parameter(parameter)
+      return [] if parameter.blank?
+
+      parameter.parameter&.filter_map do |param|
+        param.resource if param.resource&.resourceType == 'Bundle'
+      end
+    end
+
+    def extract_questionnaire_from_questionnaire_package(questionnaire_pkg_json, questionnaire_url)
+      resource = FHIR.from_contents(questionnaire_pkg_json)
+      questionnaire_bundles = extract_questionnaire_bundles(resource)
+      questionnaires = extract_questionnaires_from_bundles(questionnaire_bundles)
+
+      questionnaires.find { |q| q.url == questionnaire_url }
+    end
+
+    def extract_libraries_from_bundles(questionnaire_bundles)
+      questionnaire_bundles.filter_map do |qb|
+        qb.entry.filter_map { |entry| entry.resource if entry&.resource.is_a?(FHIR::Library) }
+      end&.flatten&.compact
+    end
+  end
+end

--- a/lib/davinci_dtr_test_kit/server/v2.2.0/dtr_payer_server_suite.rb
+++ b/lib/davinci_dtr_test_kit/server/v2.2.0/dtr_payer_server_suite.rb
@@ -79,14 +79,14 @@ module DaVinciDTRTestKit
           title 'Questionnaire Interactions'
 
           group do
-            title 'Request Validation'
-            simulation_verification
-          end
-
-          group do
             title 'Interactions'
             # TODO: make #questionnaire_interaction identify static/adaptive questionnaires
             test from: :dtr_v220_payer_interaction
+          end
+
+          group do
+            title 'Request Validation'
+            simulation_verification
           end
         end
 
@@ -170,6 +170,8 @@ module DaVinciDTRTestKit
 
       group do
         title 'Log Questionnaire Error Support'
+        # TODO
+        # (optionally ?) perform $q-p operation and validate input
 
         # TODO
         # oper-1 - shall support it

--- a/lib/davinci_dtr_test_kit/server/v2.2.0/dtr_payer_server_suite.rb
+++ b/lib/davinci_dtr_test_kit/server/v2.2.0/dtr_payer_server_suite.rb
@@ -5,7 +5,7 @@ module DaVinciDTRTestKit
   module DTRPayerServerV220
     class DTRPayerServerSuiteV220 < Inferno::TestSuite
       id :dtr_payer_server_v220
-      title 'Da Vinci DTR Client Simulator Suite v2.2.0' # Payer Server v2.2.0 Test Suite' - currently no verification, just simulation  # rubocop:disable Layout/LineLength
+      title 'Da Vinci Payer Server Test Suite v2.2.0'
       description File.read(File.join(__dir__, 'dtr_payer_server_suite_description_v220.md'))
 
       links [
@@ -27,13 +27,13 @@ module DaVinciDTRTestKit
         }
       ]
 
-      # requirement_sets(
-      #   {
-      #     identifier: 'hl7.fhir.us.davinci-dtr_2.0.1',
-      #     title: 'Da Vinci Documentation Templates and Rules (DTR) v2.0.1',
-      #     actor: 'Payer Service'
-      #   }
-      # )
+      requirement_sets(
+        {
+          identifier: 'hl7.fhir.us.davinci-dtr_2.2.0',
+          title: 'Da Vinci Documentation Templates and Rules (DTR) v2.2.0',
+          actor: 'Payer Service'
+        }
+      )
 
       fhir_resource_validator do
         igs('hl7.fhir.us.davinci-dtr#2.2.0')

--- a/lib/davinci_dtr_test_kit/server/v2.2.0/dtr_payer_server_suite.rb
+++ b/lib/davinci_dtr_test_kit/server/v2.2.0/dtr_payer_server_suite.rb
@@ -1,5 +1,6 @@
 require 'smart_app_launch_test_kit'
 require_relative 'interaction_test'
+require_relative 'questionnaire_package_support/questionnaire_response_validation_test'
 
 module DaVinciDTRTestKit
   module DTRPayerServerV220
@@ -47,11 +48,21 @@ module DaVinciDTRTestKit
             title: 'Payer FHIR Server Base Url',
             description: 'Base FHIR URL implementing the DTR server operations.'
 
-      group from: :'smart_stu2-smart_backend_services'
+      group do
+        title 'Discovery'
+
+        # TODO
+        # conf-1 - CS matches CS in the IG
+      end
+
+      group from: :'smart_stu2-smart_backend_services' do
+        # TODO
+        # spec-120 [QUESTIONABLE]- payers require clients to use backend services
+      end
 
       group do
         id :dtr_payer_server_v220_questionnaires
-        title 'Payer serves Questionnaires'
+        title 'Questionnaire Operations'
         run_as_group
 
         input :backend_services_smart_auth_info,
@@ -64,7 +75,112 @@ module DaVinciDTRTestKit
           auth_info :backend_services_smart_auth_info
         end
 
-        test from: :dtr_v220_payer_interaction
+        group do
+          title 'Questionnaire Interactions'
+
+          group do
+            title 'Request Validation'
+            simulation_verification
+          end
+
+          group do
+            title 'Interactions'
+            # TODO: make #questionnaire_interaction identify static/adaptive questionnaires
+            test from: :dtr_v220_payer_interaction
+          end
+        end
+
+        group do
+          title 'Questionnaire/$questionnaire-package Support'
+
+          # TODO: verify that each of these parameter types is used
+          # One with questionnaire url
+          # One with CRD/PAS context ID
+          # Request/Encounter resource
+
+          # TODO: base response validation
+          # oper-10 - verify response conforms to profile [DONE]
+          # oper-12 - [NOT TESTED in 2.0] include Questionnaire as 1st entry, [TESTED] and CQL libraries
+          # oper-14 - [NOT TESTED in 2.0] Bundle includes all VS instances
+          # oper-16 - [NOT TESTED in 2.0] references are version specific
+          # sec-4 - no hidden read-only questions
+          test from: :dtr_v220_payer_questionnaire_response_validation
+
+          # TODO: embedded QR validation
+          # spec-25 - [NOT TESTED in 2.0] QR has contained Q
+          # spec-122 - [NOT TESTED in 2.0] QR.Q points to canonical of the Q provided
+          # spec-139 - All references in QR are to contained or client resources
+          # spec-141 - contained resources only in item.answer
+
+          # TODO
+          # oper-9 - make a request with a known bad questionnaire url
+        end
+
+        group do
+          title 'Questionnaire/$next-question support'
+          optional
+          # TODO
+          # spec-23 - adaptive form validation [DONE]
+          # spec-24 - [NOT TESTED in 2.0] url shall be a sub-url, accessed using same credentials
+
+          # TODO
+          # sec-4 - no hidden read-only questions
+
+          # TODO
+          # spec-39 - [QUESTIONABLE] display item indicating Q completion included at end
+        end
+
+        group do
+          title 'Questionnaire design'
+
+          # TODO
+          # spec-17 - verify that Questionnaires use enableWhen/enableWhenExpression
+          # spec-18 - verify CQL is used for expressions [DONE]
+          # spec-54 - Qs include population logic [DONE]
+
+          # TODO
+          # spec-93 - [NOT TESTED in 2.0] CQL has context of "Patient"
+          # spec-94 - [NOT TESTED in 2.0] CQL follows SDC rules for determining context
+
+          # TODO
+          # spec-87 - libraries are referenced with cqf-library extension and included [DONE]
+          # spec-98 - Library names shall be unique within a Q package [DONE]
+          # spec-95 - CQL and ELM are provided in libraries [DONE]
+          # spec-99 - Libraries send CQL and ELM in content.data [DONE]
+          # oper-13 - Libraries include both CQL and EML representations [DONE]
+          # spec-96 - [NOT TESTED in 2.0] CQL and ELM are provided in expressions
+          # spec-97 [QUESTIONABLE] - [NOT TESTED in 2.0] variables reference library if multiple libraries are used
+
+          # TODO
+          # spec-160 - contained binary resources shall be pdfs or xhtml
+          # spec-165 [QUESTIONABLE]- contained binary page reference validation
+        end
+
+        group do
+          title 'ValueSet/$expand Support'
+          # [NOT TESTED]
+
+          # TODO
+          # oper-5 - VS shall use current date and only include active codes
+
+          # TODO
+          # oper-15 - [NOT TESTED in 2.0] VS with <40 entries SHALL be expanded
+        end
+      end
+
+      group do
+        title 'Log Questionnaire Error Support'
+
+        # TODO
+        # oper-1 - shall support it
+      end
+
+      group do
+        title 'Error Handling'
+
+        # TODO
+        # spec-130 - 4xx w/OO for issues with source data
+        # spec-147 - 400 w/OO for invalid QR
       end
     end
   end

--- a/lib/davinci_dtr_test_kit/server/v2.2.0/dtr_payer_server_suite.rb
+++ b/lib/davinci_dtr_test_kit/server/v2.2.0/dtr_payer_server_suite.rb
@@ -111,9 +111,6 @@ module DaVinciDTRTestKit
           # spec-122 - [NOT TESTED in 2.0] QR.Q points to canonical of the Q provided
           # spec-139 - All references in QR are to contained or client resources
           # spec-141 - contained resources only in item.answer
-
-          # TODO
-          # oper-9 - make a request with a known bad questionnaire url
         end
 
         group do
@@ -181,7 +178,12 @@ module DaVinciDTRTestKit
         title 'Error Handling'
 
         # TODO
+        # oper-9 - make a request with a known bad questionnaire url
+
+        # TODO
         # spec-130 - 4xx w/OO for issues with source data
+
+        # TODO
         # spec-147 - 400 w/OO for invalid QR
       end
     end

--- a/lib/davinci_dtr_test_kit/server/v2.2.0/questionnaire_package_support/questionnaire_response_validation_test.rb
+++ b/lib/davinci_dtr_test_kit/server/v2.2.0/questionnaire_package_support/questionnaire_response_validation_test.rb
@@ -1,0 +1,55 @@
+require_relative '../../../tags'
+require_relative '../../../urls'
+require_relative '../../validation_test'
+require_relative '../../../cross_suite/v2.2.0/questionnaire_operation_validation'
+
+module DaVinciDTRTestKit
+  module DTRPayerServerV220
+    class QuestionnaireResponseValidationTest < Inferno::Test
+      include URLs
+      include DaVinciDTRTestKit::ValidationTest
+      include QuestionnaireOperationValidation
+
+      id :dtr_v220_payer_questionnaire_response_validation
+      # TODO: this is all placeholder just to demonstrate what the basic
+      #       response validation will look like
+
+      title 'Validate that the response conforms to the DTR Questionnaire Package operation definition.'
+      description %(
+        Inferno will validate that the payer server's response to the
+        questionnaire-package operation is conformant to the [Questionnaire
+        Package operation
+        definition](https://hl7.org/fhir/us/davinci-dtr/2.2.0/en/OperationDefinition-questionnaire-package.html).
+        This includes verifying that the response conforms to the [DTR
+        Questionnaire Package Bundle
+        profile](https://hl7.org/fhir/us/davinci-dtr/2.2.0/en/StructureDefinition-DTR-QPackageBundle.html)
+        and, in the event that the server includes that Bundle in a Parameters
+        object, the [DTR Questionnaire Package Output Parameters
+        profile](https://hl7.org/fhir/us/davinci-dtr/2.2.0/en/StructureDefinition-dtr-qpackage-output-parameters.html).
+
+        It verifies the presence of mandatory elements and that elements with
+        required bindings contain appropriate values. CodeableConcept element
+        bindings will fail if none of their codings have a code/system belonging
+        to the bound ValueSet. Quantity, Coding, and code element bindings will
+        fail if their code/system are not found in the valueset.
+      )
+      verifies_requirements 'hl7.fhir.us.davinci-dtr_2.2.0@oper-10'
+      input :url
+
+      run do
+        load_tagged_requests(QUESTIONNAIRE_TAG)
+
+        skip_if requests.blank?, 'No $questionnaire-package requests were made'
+
+        requests.each do |request|
+          assert_response_status([200, 201], response: request.response)
+
+          resource = FHIR.from_contents(request.response_body)
+
+          # NOTE: This interface is not finalized
+          perform_questionnaire_package_validation(resource)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Summary
This branch contains a basic skeleton of what the completed 2.2 payer suite will look like.

# Testing Guidance
A placeholder test to perform validation on the `$questionnaire-package` response was added, which may fail, but otherwise the actual tests in the suite haven't changed, they've just been reorganized, so there shouldn't be any changes to the current client simulation.

# Anticipated Provider-side Test Impact
@karlnaden I'd be interested in any feedback regarding how/whether this organization will impact running against the client suite.