### PR TITLE
FQM-432: Add basic response validation

### DIFF
--- a/lib/davinci_dtr_test_kit/cross_suite/v2.2.0/questionnaire_operation_validation.rb
+++ b/lib/davinci_dtr_test_kit/cross_suite/v2.2.0/questionnaire_operation_validation.rb
@@ -1,19 +1,8 @@
 # NOTE: this is just copied from 2.0.1 'cql_test', and hasn't been updated yet
 module DaVinciDTRTestKit
   module QuestionnaireOperationValidation
-    STATIC_QUESTIONNAIRE_PACKAGE_BUNDLE_PROFILE = 'http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/DTR-QPackageBundle|2.2.0'.freeze
-    STATIC_QUESTIONNAIRE_PACKAGE_PARAMETER_PROFILE = 'http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/dtr-qpackage-output-parameters|2.2.0'.freeze
-    ADAPTIVE_QUESTIONNAIRE_PACKAGE_BUNDLE_PROFILE = 'http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/DTR-QPackageBundle|2.2.0'.freeze
-    ADAPTIVE_QUESTIONNAIRE_PACKAGE_PARAMETER_PROFILE = 'http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/dtr-qpackage-output-parameters|2.2.0'.freeze
-
-    def questionnaire_package_profile_urls
-      {
-        static_bundle: STATIC_QUESTIONNAIRE_PACKAGE_BUNDLE_PROFILE,
-        static_parameter: STATIC_QUESTIONNAIRE_PACKAGE_PARAMETER_PROFILE,
-        adaptive_bundle: ADAPTIVE_QUESTIONNAIRE_PACKAGE_BUNDLE_PROFILE,
-        adaptive_parameter: ADAPTIVE_QUESTIONNAIRE_PACKAGE_PARAMETER_PROFILE
-      }
-    end
+    QUESTIONNAIRE_PACKAGE_BUNDLE_PROFILE = 'http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/DTR-QPackageBundle|2.2.0'.freeze
+    QUESTIONNAIRE_PACKAGE_PARAMETER_PROFILE = 'http://hl7.org/fhir/us/davinci-dtr/StructureDefinition/dtr-qpackage-output-parameters|2.2.0'.freeze
 
     def extension_presence
       @extension_presence ||= { 'found_min_launch_context' => false, 'found_min_variable' => false,
@@ -22,334 +11,334 @@ module DaVinciDTRTestKit
                                 'found_min_cqf_lib' => false }
     end
 
-    def cql_presence
-      @cql_presence ||= { 'launch_context' => true, 'variable' => true,
-                          'pop_context' => true, 'init_expression' => true,
-                          'candidate_expression' => true, 'context_expression' => true }
-    end
+    # def cql_presence
+    #   @cql_presence ||= { 'launch_context' => true, 'variable' => true,
+    #                       'pop_context' => true, 'init_expression' => true,
+    #                       'candidate_expression' => true, 'context_expression' => true }
+    # end
 
-    def cqf_reference_libraries
-      scratch[:cqf_reference_libraries] ||= Set.new
-    end
+    # def cqf_reference_libraries
+    #   scratch[:cqf_reference_libraries] ||= Set.new
+    # end
 
-    def library_urls
-      scratch[:library_urls] ||= Set.new
-    end
+    # def library_urls
+    #   scratch[:library_urls] ||= Set.new
+    # end
 
-    def library_names
-      scratch[:library_names] ||= Set.new
-    end
+    # def library_names
+    #   scratch[:library_names] ||= Set.new
+    # end
 
-    def found_questionnaire
-      @found_questionnaire ||= false
-    end
+    # def found_questionnaire
+    #   @found_questionnaire ||= false
+    # end
 
-    def found_duplicate_library_name
-      @found_duplicate_library_name ||= false
-    end
+    # def found_duplicate_library_name
+    #   @found_duplicate_library_name ||= false
+    # end
 
-    def found_non_cql_elm_library
-      @found_non_cql_elm_library ||= false
-    end
+    # def found_non_cql_elm_library
+    #   @found_non_cql_elm_library ||= false
+    # end
 
-    def found_non_cql_expression
-      @found_non_cql_expression ||= false
-    end
+    # def found_non_cql_expression
+    #   @found_non_cql_expression ||= false
+    # end
 
-    def reset_cql_tests
-      library_names.clear
-      library_urls.clear
-      cqf_reference_libraries.clear
-      extension_presence.each_key { |k| extension_presence[k] = false }
-    end
+    # def reset_cql_tests
+    #   library_names.clear
+    #   library_urls.clear
+    #   cqf_reference_libraries.clear
+    #   extension_presence.each_key { |k| extension_presence[k] = false }
+    # end
 
-    def verify_questionnaire_extensions(questionnaires)
-      assert questionnaires&.any? && questionnaires.all?(FHIR::Questionnaire), 'No questionnaires found.'
-      questionnaires.each_with_index { |q, q_index| check_questionnaire_extensions(q, q_index) }
-      check_library_references
-      assert extension_presence.value?(true), 'No extensions found. Questionnaire must demonstrate prepopulation.'
-      assert cql_presence['variable'], 'Variable expression logic not written in CQL.'
-      assert cql_presence['launch_context'], 'Launch context expression logic not written in CQL.'
-      assert cql_presence['pop_context'], 'Population context expression logic not written in CQL.'
-    end
+    # def verify_questionnaire_extensions(questionnaires)
+    #   assert questionnaires&.any? && questionnaires.all?(FHIR::Questionnaire), 'No questionnaires found.'
+    #   questionnaires.each_with_index { |q, q_index| check_questionnaire_extensions(q, q_index) }
+    #   check_library_references
+    #   assert extension_presence.value?(true), 'No extensions found. Questionnaire must demonstrate prepopulation.'
+    #   assert cql_presence['variable'], 'Variable expression logic not written in CQL.'
+    #   assert cql_presence['launch_context'], 'Launch context expression logic not written in CQL.'
+    #   assert cql_presence['pop_context'], 'Population context expression logic not written in CQL.'
+    # end
 
-    def check_questionnaire_extensions(questionnaire, q_index)
-      # are extensions present in this questionnaire?
-      found_launch_context = found_variable = found_pop_context = found_cqf_lib = false
-      cqf_count = total_cqf_libs(questionnaire.extension)
-      misformatted_expressions = []
-      questionnaire.extension.each_with_index do |extension, index|
-        if extension.url == 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-launchContext'
-          found_launch_context = true
-          extension_presence['found_min_launch_context'] = true
-          check_for_cql(extension, 'launch_context', index, q_index, extension.url)
-          misformatted_expressions << check_expression_format(extension, index)
-        end
-        if extension.url == 'http://hl7.org/fhir/StructureDefinition/variable'
-          found_variable = true
-          extension_presence['found_min_variable'] = true
-          check_for_cql(extension, 'variable', index, q_index, extension.url)
-          misformatted_expressions << check_expression_format(extension, index)
-        end
-        if extension.url == 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-itemPopulationContext'
-          found_pop_context = true
-          extension_presence['found_min_pop_context'] = true
-          check_for_cql(extension, 'pop_context', index, q_index, extension.url)
-          misformatted_expressions << check_expression_format(extension, index)
-        end
-        next unless extension.url == 'http://hl7.org/fhir/StructureDefinition/cqf-library'
+    # def check_questionnaire_extensions(questionnaire, q_index)
+    #   # are extensions present in this questionnaire?
+    #   found_launch_context = found_variable = found_pop_context = found_cqf_lib = false
+    #   cqf_count = total_cqf_libs(questionnaire.extension)
+    #   misformatted_expressions = []
+    #   questionnaire.extension.each_with_index do |extension, index|
+    #     if extension.url == 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-launchContext'
+    #       found_launch_context = true
+    #       extension_presence['found_min_launch_context'] = true
+    #       check_for_cql(extension, 'launch_context', index, q_index, extension.url)
+    #       misformatted_expressions << check_expression_format(extension, index)
+    #     end
+    #     if extension.url == 'http://hl7.org/fhir/StructureDefinition/variable'
+    #       found_variable = true
+    #       extension_presence['found_min_variable'] = true
+    #       check_for_cql(extension, 'variable', index, q_index, extension.url)
+    #       misformatted_expressions << check_expression_format(extension, index)
+    #     end
+    #     if extension.url == 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-itemPopulationContext'
+    #       found_pop_context = true
+    #       extension_presence['found_min_pop_context'] = true
+    #       check_for_cql(extension, 'pop_context', index, q_index, extension.url)
+    #       misformatted_expressions << check_expression_format(extension, index)
+    #     end
+    #     next unless extension.url == 'http://hl7.org/fhir/StructureDefinition/cqf-library'
 
-        cqf_reference_libraries.add(extension.valueCanonical)
-        found_cqf_lib = true
-        extension_presence['found_min_cqf_lib'] = true
+    #     cqf_reference_libraries.add(extension.valueCanonical)
+    #     found_cqf_lib = true
+    #     extension_presence['found_min_cqf_lib'] = true
 
-        check_for_cql(extension, '', index, q_index, extension.url)
-      end
-      add_launch_context_messages(found_launch_context, found_variable, found_pop_context, found_cqf_lib, q_index)
-      return if cqf_count < 1
+    #     check_for_cql(extension, '', index, q_index, extension.url)
+    #   end
+    #   add_launch_context_messages(found_launch_context, found_variable, found_pop_context, found_cqf_lib, q_index)
+    #   return if cqf_count < 1
 
-      add_formatting_messages(misformatted_expressions, q_index)
-      assert misformatted_expressions.compact.empty?, 'Expression in questionnaire misformatted.'
-    end
+    #   add_formatting_messages(misformatted_expressions, q_index)
+    #   assert misformatted_expressions.compact.empty?, 'Expression in questionnaire misformatted.'
+    # end
 
-    def verify_questionnaire_items(questionnaires, final_cql_test: false)
-      assert questionnaires&.any? && questionnaires.all?(FHIR::Questionnaire), 'No questionnaires found.'
-      questionnaires.each_with_index { |q, q_index| check_questionnaire_items(q, q_index) }
+    # def verify_questionnaire_items(questionnaires, final_cql_test: false)
+    #   assert questionnaires&.any? && questionnaires.all?(FHIR::Questionnaire), 'No questionnaires found.'
+    #   questionnaires.each_with_index { |q, q_index| check_questionnaire_items(q, q_index) }
 
-      begin
-        assert !found_non_cql_expression, 'Found non-cql expression.'
-        assert extension_presence.value?(true), 'No extensions found. Questionnaire must demonstrate prepopulation.'
-        assert cql_presence['init_expression'], 'Initial expression logic not written in CQL.'
-        assert cql_presence['candidate_expression'], 'Candidate expression logic not written in CQL.'
-        assert cql_presence['context_expression'], 'Context expression logic not written in CQL.'
-      ensure
-        reset_cql_tests if final_cql_test
-      end
-    end
+    #   begin
+    #     assert !found_non_cql_expression, 'Found non-cql expression.'
+    #     assert extension_presence.value?(true), 'No extensions found. Questionnaire must demonstrate prepopulation.'
+    #     assert cql_presence['init_expression'], 'Initial expression logic not written in CQL.'
+    #     assert cql_presence['candidate_expression'], 'Candidate expression logic not written in CQL.'
+    #     assert cql_presence['context_expression'], 'Context expression logic not written in CQL.'
+    #   ensure
+    #     reset_cql_tests if final_cql_test
+    #   end
+    # end
 
-    def add_launch_context_messages(found_launch_context, found_variable, found_pop_context, found_cqf_lib, q_index)
-      unless found_launch_context
-        messages << { type: 'info',
-                      message: format_markdown("[questionnaire #{q_index + 1}] included no launch context.") }
-      end
-      unless found_variable
-        messages << { type: 'info',
-                      message: format_markdown("[questionnaire #{q_index + 1}]
-                       included no variable to query for additional data.") }
-      end
-      unless found_pop_context
-        messages << { type: 'info',
-                      message: format_markdown("[questionnaire #{q_index + 1}]
-                       included no item population context.") }
-      end
-      return if found_cqf_lib
+    # def add_launch_context_messages(found_launch_context, found_variable, found_pop_context, found_cqf_lib, q_index)
+    #   unless found_launch_context
+    #     messages << { type: 'info',
+    #                   message: format_markdown("[questionnaire #{q_index + 1}] included no launch context.") }
+    #   end
+    #   unless found_variable
+    #     messages << { type: 'info',
+    #                   message: format_markdown("[questionnaire #{q_index + 1}]
+    #                    included no variable to query for additional data.") }
+    #   end
+    #   unless found_pop_context
+    #     messages << { type: 'info',
+    #                   message: format_markdown("[questionnaire #{q_index + 1}]
+    #                    included no item population context.") }
+    #   end
+    #   return if found_cqf_lib
 
-      messages << { type: 'info',
-                    message: format_markdown("[questionnaire #{q_index + 1}]
-                      included no cqf library.") }
-    end
+    #   messages << { type: 'info',
+    #                 message: format_markdown("[questionnaire #{q_index + 1}]
+    #                   included no cqf library.") }
+    # end
 
-    def add_formatting_messages(misformatted_expressions, q_index)
-      misformatted_expressions.compact.each do |idx|
-        messages << { type: 'info',
-                      message: format_markdown("[expression #{idx + 1}] in [questionnaire #{q_index + 1}]
-                      does not begin with a reference to an included library name.") }
-      end
-    end
+    # def add_formatting_messages(misformatted_expressions, q_index)
+    #   misformatted_expressions.compact.each do |idx|
+    #     messages << { type: 'info',
+    #                   message: format_markdown("[expression #{idx + 1}] in [questionnaire #{q_index + 1}]
+    #                   does not begin with a reference to an included library name.") }
+    #   end
+    # end
 
-    def total_cqf_libs(extensions)
-      cqf_count = 0
-      extensions.each do |extension|
-        next unless extension.url == 'http://hl7.org/fhir/StructureDefinition/cqf-library'
+    # def total_cqf_libs(extensions)
+    #   cqf_count = 0
+    #   extensions.each do |extension|
+    #     next unless extension.url == 'http://hl7.org/fhir/StructureDefinition/cqf-library'
 
-        cqf_count += 1
-      end
-      cqf_count
-    end
+    #     cqf_count += 1
+    #   end
+    #   cqf_count
+    # end
 
-    def add_item_messages(found_item_expressions, q_index)
-      unless found_item_expressions['found_candidate_expression']
-        messages << { type: 'info',
-                      message: format_markdown("[questionnaire #{q_index + 1}] included no candidate expression.") }
-      end
-      unless found_item_expressions['found_init_expression']
-        messages << { type: 'info',
-                      message: format_markdown("[questionnaire #{q_index + 1}] included no initial expression.") }
-      end
-      return if found_item_expressions['found_context_expression']
+    # def add_item_messages(found_item_expressions, q_index)
+    #   unless found_item_expressions['found_candidate_expression']
+    #     messages << { type: 'info',
+    #                   message: format_markdown("[questionnaire #{q_index + 1}] included no candidate expression.") }
+    #   end
+    #   unless found_item_expressions['found_init_expression']
+    #     messages << { type: 'info',
+    #                   message: format_markdown("[questionnaire #{q_index + 1}] included no initial expression.") }
+    #   end
+    #   return if found_item_expressions['found_context_expression']
 
-      messages << { type: 'info',
-                    message: format_markdown("[questionnaire #{q_index + 1}] included no context expression.") }
-    end
+    #   messages << { type: 'info',
+    #                 message: format_markdown("[questionnaire #{q_index + 1}] included no context expression.") }
+    # end
 
-    def check_questionnaire_items(questionnaire, q_index)
-      # are expressions present in this questionnaire?
-      found_item_expressions = { 'found_init_expression' => false,
-                                 'found_candidate_expression' => false,
-                                 'found_context_expression' => false }
-      cqf_count = total_cqf_libs(questionnaire.extension)
-      misformatted_expressions = []
+    # def check_questionnaire_items(questionnaire, q_index)
+    #   # are expressions present in this questionnaire?
+    #   found_item_expressions = { 'found_init_expression' => false,
+    #                              'found_candidate_expression' => false,
+    #                              'found_context_expression' => false }
+    #   cqf_count = total_cqf_libs(questionnaire.extension)
+    #   misformatted_expressions = []
 
-      # check questionnaire items
-      questionnaire.item.each_with_index do |item, index|
-        misformatted_expressions.concat(check_nested_items(item, index, q_index, found_item_expressions, item.linkId))
-        # check extensions on items
-        item.extension.each do |item_ext|
-          misformatted_expressions << check_item_extension(item_ext,
-                                                           index, q_index, found_item_expressions, item.linkId)
-        end
-      end
-      add_item_messages(found_item_expressions, q_index)
-      # only care about formatting when there are multiple cqf libs
-      return if cqf_count < 1
+    #   # check questionnaire items
+    #   questionnaire.item.each_with_index do |item, index|
+    #     misformatted_expressions.concat(check_nested_items(item, index, q_index, found_item_expressions, item.linkId))
+    #     # check extensions on items
+    #     item.extension.each do |item_ext|
+    #       misformatted_expressions << check_item_extension(item_ext,
+    #                                                        index, q_index, found_item_expressions, item.linkId)
+    #     end
+    #   end
+    #   add_item_messages(found_item_expressions, q_index)
+    #   # only care about formatting when there are multiple cqf libs
+    #   return if cqf_count < 1
 
-      misformatted_expressions.compact.to_set.each do |idx|
-        messages << { type: 'info',
-                      message: format_markdown("[item #{idx + 1}] in [questionnaire #{q_index + 1}]
-                      contains expression that does not begin with a reference to an included library name.") }
-      end
-      assert misformatted_expressions.compact.to_set.empty?, 'Expression in questionnaire misformatted.'
-    end
+    #   misformatted_expressions.compact.to_set.each do |idx|
+    #     messages << { type: 'info',
+    #                   message: format_markdown("[item #{idx + 1}] in [questionnaire #{q_index + 1}]
+    #                   contains expression that does not begin with a reference to an included library name.") }
+    #   end
+    #   assert misformatted_expressions.compact.to_set.empty?, 'Expression in questionnaire misformatted.'
+    # end
 
-    def evaluate_library(library)
-      found_cql = found_elm = false
-      library.content.each do |content|
-        if content.data.nil?
-          messages << { type: 'info',
-                        message: format_markdown("[library #{library.url}] content element included no data.") }
-        end
-        if content.contentType == 'text/cql'
-          found_cql = true
-        elsif content.contentType == 'application/elm+json'
-          found_elm = true
-        else
-          messages << { type: 'info',
-                        message: format_markdown("[library #{library.url}] has non-cql/elm content.") }
-          true
-        end
-        next unless library_names.include? library.name
+    # def evaluate_library(library)
+    #   found_cql = found_elm = false
+    #   library.content.each do |content|
+    #     if content.data.nil?
+    #       messages << { type: 'info',
+    #                     message: format_markdown("[library #{library.url}] content element included no data.") }
+    #     end
+    #     if content.contentType == 'text/cql'
+    #       found_cql = true
+    #     elsif content.contentType == 'application/elm+json'
+    #       found_elm = true
+    #     else
+    #       messages << { type: 'info',
+    #                     message: format_markdown("[library #{library.url}] has non-cql/elm content.") }
+    #       true
+    #     end
+    #     next unless library_names.include? library.name
 
-        found_duplicate_library_name = true
-        messages << { type: 'info', message: format_markdown("[library #{library.url}] has a name,
-         #{library.name}, that is already included in the bundle.") }
-        assert !found_duplicate_library_name, 'Found duplicate library names - all names must be unique.'
-      end
-      assert found_cql, "[library #{library.url}] does not include CQL."
-      assert found_elm, "[library #{library.url}] does not include ELM."
-    end
+    #     found_duplicate_library_name = true
+    #     messages << { type: 'info', message: format_markdown("[library #{library.url}] has a name,
+    #      #{library.name}, that is already included in the bundle.") }
+    #     assert !found_duplicate_library_name, 'Found duplicate library names - all names must be unique.'
+    #   end
+    #   assert found_cql, "[library #{library.url}] does not include CQL."
+    #   assert found_elm, "[library #{library.url}] does not include ELM."
+    # end
 
-    def check_libraries(questionnaire_bundles)
-      libraries = extract_libraries_from_bundles(questionnaire_bundles)
+    # def check_libraries(questionnaire_bundles)
+    #   libraries = extract_libraries_from_bundles(questionnaire_bundles)
 
-      assert libraries.any?, 'No Libraries found.'
+    #   assert libraries.any?, 'No Libraries found.'
 
-      libraries.each do |lib|
-        library_urls.add(lib.url) unless lib.url.nil?
-        evaluate_library(lib)
-        library_names.add(lib.name)
-      end
-    end
+    #   libraries.each do |lib|
+    #     library_urls.add(lib.url) unless lib.url.nil?
+    #     evaluate_library(lib)
+    #     library_names.add(lib.name)
+    #   end
+    # end
 
-    def check_library_references
-      missing_references = cqf_reference_libraries.select do |url|
-        library_urls.exclude? url
-      end
-      assert missing_references.empty?,
-             "Some libraries referenced by cqf-libraries were not found: #{missing_references.join(', ')}"
-    end
+    # def check_library_references
+    #   missing_references = cqf_reference_libraries.select do |url|
+    #     library_urls.exclude? url
+    #   end
+    #   assert missing_references.empty?,
+    #          "Some libraries referenced by cqf-libraries were not found: #{missing_references.join(', ')}"
+    # end
 
-    def check_item_extension(item_ext, index, q_index, found_item_expressions, link_id)
-      if item_ext.url == 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression'
-        found_item_expressions['found_candidate_expression'] = true
-        extension_presence['found_min_candidate_expression'] = true
-        check_for_cql(item_ext, 'candidate_expression', index, q_index, item_ext.url, link_id)
-        return check_expression_format(item_ext, index)
-      end
-      if item_ext.url == 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression'
-        found_item_expressions['found_init_expression'] = true
-        extension_presence['found_min_init_expression'] = true
-        check_for_cql(item_ext, 'init_expression', index, q_index, item_ext.url, link_id)
-        return check_expression_format(item_ext, index)
-      end
-      if item_ext.url == 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-contextExpression'
-        found_item_expressions['found_context_expression'] = true
-        extension_presence['found_min_context_expression'] = true
-        check_for_cql(item_ext, 'context_expression', index, q_index, item_ext.url, link_id)
-        return check_expression_format(item_ext, index)
-      end
-      check_for_cql(item_ext, '', index, q_index, item_ext.url, link_id)
-    end
+    # def check_item_extension(item_ext, index, q_index, found_item_expressions, link_id)
+    #   if item_ext.url == 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-candidateExpression'
+    #     found_item_expressions['found_candidate_expression'] = true
+    #     extension_presence['found_min_candidate_expression'] = true
+    #     check_for_cql(item_ext, 'candidate_expression', index, q_index, item_ext.url, link_id)
+    #     return check_expression_format(item_ext, index)
+    #   end
+    #   if item_ext.url == 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression'
+    #     found_item_expressions['found_init_expression'] = true
+    #     extension_presence['found_min_init_expression'] = true
+    #     check_for_cql(item_ext, 'init_expression', index, q_index, item_ext.url, link_id)
+    #     return check_expression_format(item_ext, index)
+    #   end
+    #   if item_ext.url == 'http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-contextExpression'
+    #     found_item_expressions['found_context_expression'] = true
+    #     extension_presence['found_min_context_expression'] = true
+    #     check_for_cql(item_ext, 'context_expression', index, q_index, item_ext.url, link_id)
+    #     return check_expression_format(item_ext, index)
+    #   end
+    #   check_for_cql(item_ext, '', index, q_index, item_ext.url, link_id)
+    # end
 
-    def check_nested_items(item, index, q_index, found_item_expressions, link_id)
-      misformatted_nested_expressions = []
-      item.item.each do |nested_item|
-        check_nested_items(nested_item, index, q_index, found_item_expressions, nested_item.linkId)
-        nested_item.extension.each do |item_ext|
-          misformatted_nested_expressions << check_item_extension(item_ext, index, q_index, found_item_expressions,
-                                                                  link_id)
-        end
-      end
-      misformatted_nested_expressions.compact
-    end
+    # def check_nested_items(item, index, q_index, found_item_expressions, link_id)
+    #   misformatted_nested_expressions = []
+    #   item.item.each do |nested_item|
+    #     check_nested_items(nested_item, index, q_index, found_item_expressions, nested_item.linkId)
+    #     nested_item.extension.each do |item_ext|
+    #       misformatted_nested_expressions << check_item_extension(item_ext, index, q_index, found_item_expressions,
+    #                                                               link_id)
+    #     end
+    #   end
+    #   misformatted_nested_expressions.compact
+    # end
 
-    def check_expression_format(item_ext, index)
-      return unless library_names.none?
+    # def check_expression_format(item_ext, index)
+    #   return unless library_names.none?
 
-      expression_passes = false
-      library_names.each do |name|
-        if item_ext.valueExpression.expression.start_with? "\"#{name}\""
-          expression_passes = true
-          break
-        end
-      end
-      index unless expression_passes
-    end
+    #   expression_passes = false
+    #   library_names.each do |name|
+    #     if item_ext.valueExpression.expression.start_with? "\"#{name}\""
+    #       expression_passes = true
+    #       break
+    #     end
+    #   end
+    #   index unless expression_passes
+    # end
 
-    def check_for_cql(extension, extension_name, index, q_index, url, link_id = '')
-      return if extension.valueExpression.nil?
-      return if extension.valueExpression.language == 'text/cql'
+    # def check_for_cql(extension, extension_name, index, q_index, url, link_id = '')
+    #   return if extension.valueExpression.nil?
+    #   return if extension.valueExpression.language == 'text/cql'
 
-      cql_presence[extension_name] = false unless extension_name.blank?
-      messages << if link_id.blank?
-                    { type: 'info',
-                      message: format_markdown("[extension #{index + 1}] in [questionnaire #{q_index + 1}]
-                          contains expression that does not have content type of cql
-                          (URL: #{url}).") }
-                  else
-                    { type: 'info',
-                      message: format_markdown("[item #{index + 1}] in [questionnaire #{q_index + 1}]
-                          contains expression that does not have content type of cql
-                          (linkId: #{link_id}, URL: #{url}).") }
-                  end
-    end
+    #   cql_presence[extension_name] = false unless extension_name.blank?
+    #   messages << if link_id.blank?
+    #                 { type: 'info',
+    #                   message: format_markdown("[extension #{index + 1}] in [questionnaire #{q_index + 1}]
+    #                       contains expression that does not have content type of cql
+    #                       (URL: #{url}).") }
+    #               else
+    #                 { type: 'info',
+    #                   message: format_markdown("[item #{index + 1}] in [questionnaire #{q_index + 1}]
+    #                       contains expression that does not have content type of cql
+    #                       (linkId: #{link_id}, URL: #{url}).") }
+    #               end
+    # end
 
-    def extract_contained_questionnaires(questionnaire_responses)
-      questionnaire_responses&.filter_map do |qr|
-        qr.contained&.grep(FHIR::Questionnaire)
-      end&.flatten&.compact
-    end
+    # def extract_contained_questionnaires(questionnaire_responses)
+    #   questionnaire_responses&.filter_map do |qr|
+    #     qr.contained&.grep(FHIR::Questionnaire)
+    #   end&.flatten&.compact
+    # end
 
-    def extract_questionnaires_from_bundles(questionnaire_bundles)
-      questionnaire_bundles.filter_map do |qb|
-        qb.entry.filter_map { |entry| entry.resource if entry.resource.is_a?(FHIR::Questionnaire) }
-      end&.flatten&.compact
-    end
+    # def extract_questionnaires_from_bundles(questionnaire_bundles)
+    #   questionnaire_bundles.filter_map do |qb|
+    #     qb.entry.filter_map { |entry| entry.resource if entry.resource.is_a?(FHIR::Questionnaire) }
+    #   end&.flatten&.compact
+    # end
 
-    def perform_questionnaire_package_validation(resource, form = 'static')
-      scratch[:"#{form}_questionnaire_bundles"] = extract_questionnaire_bundles(resource)
-      validate_questionnaire_package(resource, form)
-      assert scratch[:"#{form}_questionnaire_bundles"].present?, 'No questionnaire bundle found in the response'
-    end
+    def perform_questionnaire_package_response_validation(resource, index)
+      bundles = extract_questionnaire_bundles(resource)
 
-    def validate_questionnaire_package(resource, form)
-      case resource&.resourceType
-      when 'Bundle'
-        assert_valid_resource(resource:, profile_url: questionnaire_package_profile_urls[:"#{form}_bundle"])
-      when 'Parameters'
-        assert_valid_resource(resource:, profile_url: questionnaire_package_profile_urls[:"#{form}_parameter"])
-      else
-        assert(false, "Unexpected resourceType: #{resource&.resourceType}. Expected Parameters or Bundle")
-      end
+      resource_is_valid?(
+        resource:,
+        profile_url: QUESTIONNAIRE_PACKAGE_PARAMETER_PROFILE,
+        message_prefix: "Request #{index}: "
+      )
+
+      return if bundles.present?
+
+      add_message(
+        'error',
+        "No Questionnaire Bundle found in response #{index}"
+      )
     end
 
     def extract_questionnaire_bundles(resource)
@@ -379,10 +368,10 @@ module DaVinciDTRTestKit
       questionnaires.find { |q| q.url == questionnaire_url }
     end
 
-    def extract_libraries_from_bundles(questionnaire_bundles)
-      questionnaire_bundles.filter_map do |qb|
-        qb.entry.filter_map { |entry| entry.resource if entry&.resource.is_a?(FHIR::Library) }
-      end&.flatten&.compact
-    end
+    # def extract_libraries_from_bundles(questionnaire_bundles)
+    #   questionnaire_bundles.filter_map do |qb|
+    #     qb.entry.filter_map { |entry| entry.resource if entry&.resource.is_a?(FHIR::Library) }
+    #   end&.flatten&.compact
+    # end
   end
 end

--- a/lib/davinci_dtr_test_kit/server/v2.2.0/client_simulation.rb
+++ b/lib/davinci_dtr_test_kit/server/v2.2.0/client_simulation.rb
@@ -3,25 +3,19 @@ require_relative '../../tags'
 module DaVinciDTRTestKit
   module DTRPayerServerV220
     module ClientSimulation
-      def questionnaire_interaction(fhir_base_url, questionnaire_package_request_parameters,
-                                    questionnaire_response_templates)
-        adaptive_questionnaire_interaction(fhir_base_url, questionnaire_package_request_parameters,
-                                           questionnaire_response_templates)
-      end
-
-      def static_questionnaire_interaction(fhir_base_url, questionnaire_package_request_parameters)
+      def questionnaire_interaction(
+        fhir_base_url,
+        questionnaire_package_request_parameters,
+        questionnaire_response_templates
+      )
         qp_response = make_questionnaire_package_request(fhir_base_url, questionnaire_package_request_parameters)
-        package_bundles = extract_response_package_bundles(qp_response)
-        find_and_expand_value_sets(package_bundles, fhir_base_url)
-      end
 
-      def adaptive_questionnaire_interaction(fhir_base_url, questionnaire_package_request_parameters,
-                                             questionnaire_response_templates)
-        qp_response = make_questionnaire_package_request(fhir_base_url, questionnaire_package_request_parameters)
         package_bundles = extract_response_package_bundles(qp_response)
+
         find_and_expand_value_sets(package_bundles, fhir_base_url)
-        adaptive_questionnaire_details = extract_adaptive_questionnaires(package_bundles,
-                                                                         questionnaire_response_templates)
+
+        adaptive_questionnaire_details =
+          extract_adaptive_questionnaires(package_bundles, questionnaire_response_templates)
         adaptive_questionnaire_details.each do |detail|
           request_adaptive_questionnaire_using_next_question(detail, fhir_base_url)
         end

--- a/lib/davinci_dtr_test_kit/server/v2.2.0/dtr_payer_server_suite.rb
+++ b/lib/davinci_dtr_test_kit/server/v2.2.0/dtr_payer_server_suite.rb
@@ -6,7 +6,7 @@ module DaVinciDTRTestKit
   module DTRPayerServerV220
     class DTRPayerServerSuiteV220 < Inferno::TestSuite
       id :dtr_payer_server_v220
-      title 'Da Vinci Payer Server Test Suite v2.2.0'
+      title 'Da Vinci DTR Payer Server Test Suite v2.2.0'
       description File.read(File.join(__dir__, 'dtr_payer_server_suite_description_v220.md'))
 
       links [
@@ -98,12 +98,9 @@ module DaVinciDTRTestKit
           # One with CRD/PAS context ID
           # Request/Encounter resource
 
-          # TODO: base response validation
-          # oper-10 - verify response conforms to profile [DONE]
           # oper-12 - [NOT TESTED in 2.0] include Questionnaire as 1st entry, [TESTED] and CQL libraries
           # oper-14 - [NOT TESTED in 2.0] Bundle includes all VS instances
           # oper-16 - [NOT TESTED in 2.0] references are version specific
-          # sec-4 - no hidden read-only questions
           test from: :dtr_v220_payer_questionnaire_response_validation
 
           # TODO: embedded QR validation
@@ -119,9 +116,6 @@ module DaVinciDTRTestKit
           # TODO
           # spec-23 - adaptive form validation [DONE]
           # spec-24 - [NOT TESTED in 2.0] url shall be a sub-url, accessed using same credentials
-
-          # TODO
-          # sec-4 - no hidden read-only questions
 
           # TODO
           # spec-39 - [QUESTIONABLE] display item indicating Q completion included at end
@@ -151,6 +145,9 @@ module DaVinciDTRTestKit
           # TODO
           # spec-160 - contained binary resources shall be pdfs or xhtml
           # spec-165 [QUESTIONABLE]- contained binary page reference validation
+
+          # TODO
+          # sec-4 - no hidden read-only questions
         end
 
         group do

--- a/lib/davinci_dtr_test_kit/server/v2.2.0/interaction_test.rb
+++ b/lib/davinci_dtr_test_kit/server/v2.2.0/interaction_test.rb
@@ -47,7 +47,7 @@ module DaVinciDTRTestKit
             description: %(
               Tester-provided list of one or more QuestionnaireResponse resources in json format
               that Inferno will use to populate answers for adaptive forms for the purpose
-              of building `Qusetionnaire/$next-question` requests to complete these forms.
+              of building `Questionnaire/$next-question` requests to complete these forms.
               If not provided, no `$next-question` requests will be performed.
             ),
             type: 'textarea',

--- a/lib/davinci_dtr_test_kit/server/v2.2.0/questionnaire_package_support/questionnaire_response_validation_test.rb
+++ b/lib/davinci_dtr_test_kit/server/v2.2.0/questionnaire_package_support/questionnaire_response_validation_test.rb
@@ -11,27 +11,13 @@ module DaVinciDTRTestKit
       include QuestionnaireOperationValidation
 
       id :dtr_v220_payer_questionnaire_response_validation
-      # TODO: this is all placeholder just to demonstrate what the basic
-      #       response validation will look like
 
-      title 'Validate that the response conforms to the DTR Questionnaire Package operation definition.'
+      title 'Verify that the response conforms to the DTR Questionnaire Package Output Parameters profile'
       description %(
-        Inferno will validate that the payer server's response to the
-        questionnaire-package operation is conformant to the [Questionnaire
-        Package operation
-        definition](https://hl7.org/fhir/us/davinci-dtr/2.2.0/en/OperationDefinition-questionnaire-package.html).
-        This includes verifying that the response conforms to the [DTR
-        Questionnaire Package Bundle
-        profile](https://hl7.org/fhir/us/davinci-dtr/2.2.0/en/StructureDefinition-DTR-QPackageBundle.html)
-        and, in the event that the server includes that Bundle in a Parameters
-        object, the [DTR Questionnaire Package Output Parameters
+        Inferno will verify that the payer server's response to the
+        questionnaire-package operation conforms to the [Questionnaire Package
+        Output Parameters
         profile](https://hl7.org/fhir/us/davinci-dtr/2.2.0/en/StructureDefinition-dtr-qpackage-output-parameters.html).
-
-        It verifies the presence of mandatory elements and that elements with
-        required bindings contain appropriate values. CodeableConcept element
-        bindings will fail if none of their codings have a code/system belonging
-        to the bound ValueSet. Quantity, Coding, and code element bindings will
-        fail if their code/system are not found in the valueset.
       )
       verifies_requirements 'hl7.fhir.us.davinci-dtr_2.2.0@oper-10'
       input :url
@@ -41,14 +27,36 @@ module DaVinciDTRTestKit
 
         skip_if requests.blank?, 'No $questionnaire-package requests were made'
 
-        requests.each do |request|
-          assert_response_status([200, 201], response: request.response)
+        requests.each_with_index do |request, index|
+          unless [200, 201].include? request.response[:status]
+            add_message(
+              'error',
+              "Request #{index} was unsuccessful."
+            )
+          end
+
+          JSON.parse(request.response_body)
 
           resource = FHIR.from_contents(request.response_body)
 
-          # NOTE: This interface is not finalized
-          perform_questionnaire_package_validation(resource)
+          if resource.nil?
+            add_message(
+              'error',
+              "Response #{index} did not contain FHIR resources."
+            )
+
+            next
+          end
+
+          perform_questionnaire_package_response_validation(resource, index)
+        rescue JSON::ParserError
+          add_message(
+            'error',
+            "Response #{index} contained invalid JSON."
+          )
         end
+
+        assert_no_error_messages('Not all responses were valid. See messages for details.')
       end
     end
   end

--- a/spec/davinci_dtr_test_kit/server/v2.2.0/questionnaire_response_validation_test_spec.rb
+++ b/spec/davinci_dtr_test_kit/server/v2.2.0/questionnaire_response_validation_test_spec.rb
@@ -1,0 +1,97 @@
+RSpec.describe DaVinciDTRTestKit::DTRPayerServerV220::QuestionnaireResponseValidationTest do # rubocop:disable RSpec/SpecFilePathFormat
+  let(:suite_id) { 'dtr_payer_server_v220' }
+  let(:results_repo) { Inferno::Repositories::Results.new }
+  let(:url) { 'https://payer.example.com/fhir' }
+
+  def result_messages
+    results_repo
+      .current_results_for_test_session_and_runnables(test_session.id, [described_class])
+      .first&.messages || []
+  end
+
+  it 'skips if no requests have been made' do
+    result = run(described_class, url:)
+
+    expect(result.result).to eq('skip')
+    expect(result.result_message).to include('No $questionnaire-package')
+  end
+
+  it 'fails if no successful requests have been made' do
+    request = repo_create(:request, status: 400, response_body: '{}')
+
+    allow_any_instance_of(described_class).to receive(:requests).and_return([request])
+
+    result = run(described_class, url:)
+
+    expect(result.result).to eq('fail')
+    expect(result.result_message).to include('Not all responses were valid')
+
+    expect(result_messages.first.message).to include('was unsuccessful')
+  end
+
+  it 'fails if a response contains invalid JSON' do
+    request = repo_create(:request)
+
+    allow_any_instance_of(described_class).to receive(:requests).and_return([request])
+
+    result = run(described_class, url:)
+
+    expect(result.result).to eq('fail')
+    expect(result.result_message).to include('Not all responses were valid')
+
+    expect(result_messages.first.message).to include('invalid JSON')
+  end
+
+  it 'fails if a response does not contain a FHIR resource' do
+    request = repo_create(:request, response_body: '{}')
+
+    allow_any_instance_of(described_class).to receive(:requests).and_return([request])
+
+    result = run(described_class, url:)
+
+    expect(result.result).to eq('fail')
+    expect(result.result_message).to include('Not all responses were valid')
+
+    expect(result_messages.first.message).to include('did not contain FHIR resources')
+  end
+
+  it 'fails if the response does not conform to the profile' do
+    parameters =
+      FHIR::Parameters.new(
+        parameter: [
+          {
+            name: 'packagebundle',
+            resource: FHIR::Bundle.new
+          }
+        ]
+      )
+    request = repo_create(:request, response_body: parameters.to_json)
+    error_message = { type: 'error', message: 'validation error' }
+
+    allow_any_instance_of(described_class).to receive(:requests).and_return([request])
+    allow_any_instance_of(described_class).to receive(:resource_is_valid?).and_return(false)
+    allow_any_instance_of(described_class).to receive(:messages).and_return([error_message])
+
+    result = run(described_class, url:)
+
+    expect(result.result).to eq('fail')
+    expect(result.result_message).to include('Not all responses were valid')
+
+    expect(result_messages.first.message).to include('validation error')
+  end
+
+  it 'fails if the response does not contain a Bundle' do
+    parameters = FHIR::Parameters.new
+    request = repo_create(:request, response_body: parameters.to_json)
+
+    allow_any_instance_of(described_class).to receive(:requests).and_return([request])
+    allow_any_instance_of(described_class).to receive(:resource_is_valid?).and_return(true)
+
+    result = run(described_class, url:)
+
+    expect(result.result).to eq('fail')
+    expect(result.result_message).to include('Not all responses were valid')
+
+    expect(result_messages.first.message).to include('No Questionnaire Bundle')
+  end
+end


### PR DESCRIPTION
# Summary
This branch adds basic response validation for the `$questionnaire-package` operation to the server suite.

# Testing Guidance
When run against the client suite, the test will fail because the response does not include a QuestionnaireResponse.

# Anticipated Provider-side Test Impact
None